### PR TITLE
Add plat sponsors to sidebar

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -142,14 +142,14 @@ export default ({
   useEffect(() => {
     getSponsors().then(docs => {
       // Only keep platinum tier sponsors for sidebar
-      const filteredDocs = docs.filter(
-        doc => doc.data().tier && doc.data().tier.toLowerCase() === 'platinum'
-      )
-      setSponsors(filteredDocs.map(doc => doc.data()))
+      const filteredDocs = docs
+        .filter(doc => doc.data().tier && doc.data().tier.toLowerCase() === 'platinum')
+        .map(doc => {
+          return doc.data()
+        })
+      setSponsors(filteredDocs)
     })
   }, [setSponsors])
-
-  const SponsorList = sponsors.map(sponsor => <SponsorLogo src={sponsor.imgURL} />)
 
   if (isJudgingOpen) {
     links.push({ location: '/judging', text: 'JUDGING' })
@@ -202,7 +202,7 @@ export default ({
           Logout
         </StyledButton>
       )}
-      {sponsors && SponsorList}
+      {sponsors && sponsors.map(sponsor => <SponsorLogo key={sponsor.name} src={sponsor.imgURL} />)}
     </SidebarContainer>
   )
 }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Link, useLocation } from 'wouter'
 import { A } from './Typography'
@@ -9,6 +9,7 @@ import cmdf_logo from '../assets/cmdf_logo.svg'
 import { Button } from './Input/index'
 import { useAuth } from '../utility/Auth'
 import { hackerStatuses } from './ApplicationDashboard'
+import { getSponsors } from '../utility/firebase'
 
 const SidebarContainer = styled.div`
   min-width: 275px;
@@ -113,9 +114,11 @@ const StatusText = styled.div`
   margin-top: 5px;
 `
 
-// const TitleSponsor = styled.img`
-//   margin: 1em 0 0 60px;
-// `
+const SponsorLogo = styled.img`
+  display: block;
+  margin: 1em 0 0 60px;
+  max-width: calc(200px - 2em);
+`
 
 export default ({
   showMobileSidebar,
@@ -134,6 +137,19 @@ export default ({
     { location: '/faq', text: 'FAQ' },
     { location: '/sponsors', text: 'SPONSORS' },
   ]
+  const [sponsors, setSponsors] = useState([])
+
+  useEffect(() => {
+    getSponsors().then(docs => {
+      // Only keep platinum tier sponsors for sidebar
+      const filteredDocs = docs.filter(
+        doc => doc.data().tier && doc.data().tier.toLowerCase() === 'platinum'
+      )
+      setSponsors(filteredDocs.map(doc => doc.data()))
+    })
+  }, [setSponsors])
+
+  const SponsorList = sponsors.map(sponsor => <SponsorLogo src={sponsor.imgURL} />)
 
   if (isJudgingOpen) {
     links.push({ location: '/judging', text: 'JUDGING' })
@@ -186,9 +202,7 @@ export default ({
           Logout
         </StyledButton>
       )}
-      {/* <a href="https://www.covalenthq.com" target="_blank" rel="noopener noreferrer">
-        <TitleSponsor src="/title_sponsor.svg" alt="Covalent logo" />
-      </a> */}
+      {sponsors && SponsorList}
     </SidebarContainer>
   )
 }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -144,9 +144,7 @@ export default ({
       // Only keep platinum tier sponsors for sidebar
       const filteredDocs = docs
         .filter(doc => doc.data().tier && doc.data().tier.toLowerCase() === 'platinum')
-        .map(doc => {
-          return doc.data()
-        })
+        .map(doc => doc.data())
       setSponsors(filteredDocs)
     })
   }, [setSponsors])


### PR DESCRIPTION
## Description
Closes #327. The code for this already existed from a previous change #304, so it's pretty straightforward. Briefly considered if the navbar should be making the call to the firestore to get the sponsors, but the alternative is changing all pages that use it (which would be a lot), so this makes sense to me.

![image](https://user-images.githubusercontent.com/5078356/145660202-dc552037-c0c3-4d09-bdda-73ef4fd0e30b.png)

