### PR TITLE
Portal flags

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,8 +45,6 @@ const PageRoute = ({ path, children }) => {
     return unsubscribe
   }, [setLivesiteDoc])
 
-  console.log(livesiteDoc.applicationsOpen)
-
   return (
     <Route path={path}>
       {livesiteDoc.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}

--- a/src/App.js
+++ b/src/App.js
@@ -38,16 +38,16 @@ const notifyUser = announcement => {
 }
 
 const PageRoute = ({ path, children }) => {
-  const [livesiteDoc, setLivesiteDoc] = useState(false)
+  const [livesiteDoc, setLivesiteDoc] = useState(null)
 
   useEffect(() => {
     const unsubscribe = getLivesiteDoc(setLivesiteDoc)
     return unsubscribe
-  }, [setLivesiteDoc])
+  }, [])
 
   return (
     <Route path={path}>
-      {livesiteDoc.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
+      {livesiteDoc?.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
     </Route>
   )
 }

--- a/src/App.js
+++ b/src/App.js
@@ -23,14 +23,8 @@ import {
   Application,
 } from './pages'
 import Page from './components/Page'
-import { db } from './utility/firebase'
-import {
-  APPLICATION_STATUS,
-  DB_COLLECTION,
-  DB_HACKATHON,
-  IS_DEVICE_IOS,
-  ONLY_APPLICATION,
-} from './utility/Constants'
+import { db, getLivesiteDoc } from './utility/firebase'
+import { APPLICATION_STATUS, DB_COLLECTION, DB_HACKATHON, IS_DEVICE_IOS } from './utility/Constants'
 import notifications from './utility/notifications'
 import { AuthProvider, getRedirectUrl, useAuth } from './utility/Auth'
 import { HackerApplicationProvider, useHackerApplication } from './utility/HackerApplicationContext'
@@ -44,9 +38,18 @@ const notifyUser = announcement => {
 }
 
 const PageRoute = ({ path, children }) => {
+  const [livesiteDoc, setLivesiteDoc] = useState(false)
+
+  useEffect(() => {
+    const unsubscribe = getLivesiteDoc(setLivesiteDoc)
+    return unsubscribe
+  }, [setLivesiteDoc])
+
+  console.log(livesiteDoc.applicationsOpen)
+
   return (
     <Route path={path}>
-      {ONLY_APPLICATION ? <Redirect to="/application" /> : <Page>{children}</Page>}
+      {livesiteDoc.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
     </Route>
   )
 }

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -2,7 +2,6 @@ export const DB_COLLECTION = 'Hackathons'
 
 // CHANGE: firebase collection name for this hackathon
 export const DB_HACKATHON = 'nwHacks2022'
-export const ONLY_APPLICATION = true // CHANGE: when not application
 export const DAYOF_COLLECTION = 'DayOf'
 export const FAQ_COLLECTION = 'FAQ'
 export const NOTIFICATION_SETTINGS_CACHE_KEY = 'livesiteNotificationSettings'


### PR DESCRIPTION
## Description
<!--- Describe your changes! Include motivation, changes you made, screenshots/video if applicable -->
- removed hardcoded use of `ONLY_APPLICATION` from `/constants.js` and instead sets the value depending on what `getLivesiteDoc` returns for the `applicationsOpen` value.
- `applicationsOpen == true` -> redirect to application page
- `applicationsOpen == false` -> redirects to day-of pages

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
Honestly not sure if I'm doing this right, or if there are other instances where the `ONLY_APPLICATION` constant is used. But `App.js` was all that I could find.
