### PR TITLE
scrollable schedule implementation

### DIFF
--- a/src/components/Schedule/Event.js
+++ b/src/components/Schedule/Event.js
@@ -19,7 +19,7 @@ const EventCard = styled(Card)`
     border: 3px solid ${p.theme.colors.secondaryWarning};
     border-radius: 7px;
     background: ${p.theme.colors.card};
-    
+
     & > h3 {
       color: ${p.theme.colors.secondaryWarning};
     }

--- a/src/components/Schedule/Schedule.js
+++ b/src/components/Schedule/Schedule.js
@@ -119,26 +119,3 @@ export default ({ events, hackathonStart, hackathonEnd }) => {
     </OverflowContainer>
   )
 }
-
-{
-  /* <OverflowContainer header="Day-Of-Events Schedule">
-  <TagLegend />
-
-  <ScheduleFlexContainer>
-    <TimelineColumn
-      hackathonStart={hackathonStart}
-      duration={durationOfHackathon}
-      numCols={schedule.length}
-    />
-    <ScrollableContainer>
-      <ColumnContainer>
-        {schedule.map((column, i) => (
-          <ScheduleColumn key={i} column={column} />
-        ))}
-      </ColumnContainer>
-    </ScrollableContainer>
-
-  </ScheduleFlexContainer>
-
-</OverflowContainer> */
-}

--- a/src/components/Schedule/Schedule.js
+++ b/src/components/Schedule/Schedule.js
@@ -6,8 +6,9 @@ import { TimelineColumn } from './Timeline'
 import { TagLegend } from './Tag'
 import Event from './Event'
 
+// Rotation transformation is done to make the scroll bar on top
 const ScrollableContainer = styled.div`
-  overflow-x: scroll;
+  overflow-x: auto;
   overflow-y: hidden;
   transform: rotateX(180deg);
   ::-webkit-scrollbar {
@@ -29,12 +30,13 @@ const ScrollableContainer = styled.div`
     background-color: #8e7eb4;
   }
 `
-
+// Content is upside down due to transformation in ScrollableContainer,
+// which needs to be flipped back
 const ScheduleFlexContainer = styled.div`
   display: flex;
   flex-direction: row;
   transform: rotateX(180deg);
-  padding-top: 15px;
+  padding-top: 30px;
 `
 
 const FlexColumn = styled.div`

--- a/src/components/Schedule/Schedule.js
+++ b/src/components/Schedule/Schedule.js
@@ -15,18 +15,18 @@ const ScrollableContainer = styled.div`
     height: 10px;
   }
   ::-webkit-scrollbar-thumb {
-    background-color: transparent;
+    background-color: #8e7eb4;
     border-radius: 10px;
-    border: 1px solid ${p => p.theme.colors.highlight};
+    border: none;
   }
   ::-webkit-scrollbar-track {
     background-color: transparent;
   }
   ::-webkit-scrollbar-corner {
-    background-color: transparent;
+    background-color: #8e7eb4;
   }
   ::-webkit-resizer {
-    background-color: transparent;
+    background-color: #8e7eb4;
   }
 `
 

--- a/src/components/Schedule/Schedule.js
+++ b/src/components/Schedule/Schedule.js
@@ -6,9 +6,35 @@ import { TimelineColumn } from './Timeline'
 import { TagLegend } from './Tag'
 import Event from './Event'
 
+const ScrollableContainer = styled.div`
+  overflow-x: scroll;
+  overflow-y: hidden;
+  transform: rotateX(180deg);
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 10px;
+    border: 1px solid ${p => p.theme.colors.highlight};
+  }
+  ::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+  ::-webkit-scrollbar-corner {
+    background-color: transparent;
+  }
+  ::-webkit-resizer {
+    background-color: transparent;
+  }
+`
+
 const ScheduleFlexContainer = styled.div`
   display: flex;
   flex-direction: row;
+  transform: rotateX(180deg);
+  padding-top: 15px;
 `
 
 const FlexColumn = styled.div`
@@ -78,16 +104,41 @@ export default ({ events, hackathonStart, hackathonEnd }) => {
   return (
     <OverflowContainer header="Day-Of-Events Schedule">
       <TagLegend />
-      <ScheduleFlexContainer>
-        <TimelineColumn
-          hackathonStart={hackathonStart}
-          duration={durationOfHackathon}
-          numCols={schedule.length}
-        />
+      <ScrollableContainer>
+        <ScheduleFlexContainer>
+          <TimelineColumn
+            hackathonStart={hackathonStart}
+            duration={durationOfHackathon}
+            numCols={schedule.length}
+          />
+          {schedule.map((column, i) => (
+            <ScheduleColumn key={i} column={column} />
+          ))}
+        </ScheduleFlexContainer>
+      </ScrollableContainer>
+    </OverflowContainer>
+  )
+}
+
+{
+  /* <OverflowContainer header="Day-Of-Events Schedule">
+  <TagLegend />
+
+  <ScheduleFlexContainer>
+    <TimelineColumn
+      hackathonStart={hackathonStart}
+      duration={durationOfHackathon}
+      numCols={schedule.length}
+    />
+    <ScrollableContainer>
+      <ColumnContainer>
         {schedule.map((column, i) => (
           <ScheduleColumn key={i} column={column} />
         ))}
-      </ScheduleFlexContainer>
-    </OverflowContainer>
-  )
+      </ColumnContainer>
+    </ScrollableContainer>
+
+  </ScheduleFlexContainer>
+
+</OverflowContainer> */
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes! Include motivation, changes you made, screenshots/video if applicable -->
#345 
![image](https://user-images.githubusercontent.com/45786074/148671549-46fc76a0-cd34-4ff0-9dd6-3ad6a89e5100.png)

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
NOTE: I think ideally the time stamps stay while the rest of the schedule is scrollable - I tried implementing this but it was an absolute CSS hell. Run into problems with the dashed lines and the columns not showing up.