### PR TITLE
Redirect to home on login for attending hackers

### DIFF
--- a/src/utility/Auth.js
+++ b/src/utility/Auth.js
@@ -71,6 +71,8 @@ const handleUser = async (setUser, setLocation) => {
 
 export const getRedirectUrl = redirect => {
   switch (redirect) {
+    case REDIRECT_STATUS.AttendingEvent:
+      return '/'
     case REDIRECT_STATUS.ApplicationAccepted:
       return '/'
     case REDIRECT_STATUS.ApplicationNotSubmitted:


### PR DESCRIPTION
## Description
If an applicant has the `attending` status and they login, they should be redirected home.
