### PR TITLE
Implement success toast

### DIFF
--- a/src/components/Judging/SubmissionForm.js
+++ b/src/components/Judging/SubmissionForm.js
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import styled from 'styled-components'
 import { Button, Select, TextArea, TextInput, Dropdown } from '../Input'
 import { ErrorSpan as Required, ErrorMessage, H1, H3, P, Label } from '../Typography'
-import ErrorBanner from '../ErrorBanner'
+import Toast from '../Toast'
 import {
   validateDiscord,
   validateEmail,
@@ -87,7 +87,16 @@ const defaultMembers = [{}, {}, {}, {}]
 
 const MAX_CHARS = 240
 
-export default ({ project, onSubmit, isSubmitting, onLeave, isLeaving, error, userData }) => {
+export default ({
+  project,
+  onSubmit,
+  isSubmitting,
+  onLeave,
+  isLeaving,
+  error,
+  successMsg,
+  userData,
+}) => {
   const [title, setTitle] = useState(project.title || '')
   const [description, setDescription] = useState(project.description || '')
   const [members, setMembers] = useState(project.teamMembers || defaultMembers)
@@ -387,7 +396,8 @@ export default ({ project, onSubmit, isSubmitting, onLeave, isLeaving, error, us
           Leave Project
         </Button>
       </ButtonContainer>
-      {error && <ErrorBanner>{error.message}</ErrorBanner>}
+      {error && <Toast>{error.message}</Toast>}
+      {successMsg && <Toast type="success">{successMsg}</Toast>}
     </div>
   )
 }

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -2,9 +2,9 @@ import React, { useEffect, useState } from 'react'
 
 import styled from 'styled-components'
 
-const ErrorDiv = styled.div`
+const ToastDiv = styled.div`
   width: 25%;
-  background-color: ${p => p.theme.colors.error};
+  background-color: ${p => (p.type === 'success' ? p.theme.colors.success : p.theme.colors.error)};
   position: fixed;
   bottom: ${p => (p.shown ? '40px' : '-100px')};
   opacity: ${p => (p.shown ? '100%' : '0%')};
@@ -17,23 +17,23 @@ const ErrorDiv = styled.div`
   border-radius: 5px;
   word-break: break-word;
 `
-const ErrorText = styled.p`
+const ToastText = styled.p`
   text-align: center;
-  color: ${p => p.theme.colors.errorText};
+  color: ${p => p.theme.colors.toastText};
   margin: 10px 20px;
 `
 
-export default function ErrorBanner({ children }) {
-  const [showError, setShowError] = useState(false)
+export default function Toast({ children, type = 'error' }) {
+  const [showToast, setShowToast] = useState(false)
 
   useEffect(() => {
     if (children) {
-      setShowError(true)
+      setShowToast(true)
     } else {
-      setShowError(false)
+      setShowToast(false)
     }
     const errorTimeOut = setTimeout(() => {
-      setShowError(false)
+      setShowToast(false)
     }, 10000)
     return () => {
       clearTimeout(errorTimeOut)
@@ -42,9 +42,9 @@ export default function ErrorBanner({ children }) {
 
   return (
     <>
-      <ErrorDiv shown={showError}>
-        <ErrorText>{children}</ErrorText>
-      </ErrorDiv>
+      <ToastDiv shown={showToast} type={type}>
+        <ToastText>{children}</ToastText>
+      </ToastDiv>
     </>
   )
 }

--- a/src/containers/SubmissionLink.js
+++ b/src/containers/SubmissionLink.js
@@ -4,11 +4,15 @@ import React, { useState, useEffect } from 'react'
 import Form from '../components/Judging/SubmissionForm'
 import { projectsRef, applicantsRef, createProject, updateProject } from '../utility/firebase'
 
+// Redirect for successful submissions + leaving of project
+const REDIRECT_TIMEOUT = 3000
+
 export default ({ user, refreshCallback }) => {
   const [project, setProject] = useState({})
   const [isSubmitting, setSubmitting] = useState(false)
   const [isLeaving, setIsLeaving] = useState(false)
   const [error, setError] = useState(null)
+  const [successMsg, setSuccessMsg] = useState('')
   const [userData, setUserData] = useState({})
 
   useEffect(() => {
@@ -90,7 +94,8 @@ export default ({ user, refreshCallback }) => {
             ...projectSubmission,
             teamMembers: validMembers,
           })
-          window.location.reload()
+          setSuccessMsg('Successfully saved project - redirecting soon!')
+          setTimeout(() => window.location.reload(), REDIRECT_TIMEOUT)
         } else {
           setError(error)
         }
@@ -146,7 +151,8 @@ export default ({ user, refreshCallback }) => {
             ...projectSubmission,
             teamMembers: validMembers,
           })
-          window.location.reload()
+          setSuccessMsg('Successfully saved project - redirecting soon!')
+          setTimeout(() => window.location.reload(), REDIRECT_TIMEOUT)
         } else {
           setError(error)
         }
@@ -179,7 +185,8 @@ export default ({ user, refreshCallback }) => {
       submittedProject: '',
     })
     setIsLeaving(false)
-    window.location.reload()
+    setSuccessMsg('Successfully left project - redirecting soon!')
+    setTimeout(() => window.location.reload(), REDIRECT_TIMEOUT)
   }
 
   return (
@@ -191,6 +198,7 @@ export default ({ user, refreshCallback }) => {
       isLeaving={isLeaving}
       userData={userData}
       error={error}
+      successMsg={successMsg}
     />
   )
 }

--- a/src/pages/Judging/View.js
+++ b/src/pages/Judging/View.js
@@ -3,7 +3,7 @@ import { useLocation, Link } from 'wouter'
 import HeroPage, { Loading, JudgingNotOpen } from '../../components/HeroPage'
 import ViewProject from '../../components/Judging/ViewProject'
 import { A } from '../../components/Typography'
-import ErrorBanner from '../../components/ErrorBanner'
+import Toast from '../../components/Toast'
 import { getLivesiteDoc, projectsRef, applicantsRef, submitGrade } from '../../utility/firebase'
 import { useAuth } from '../../utility/Auth'
 import { defaultScoreFromRubric, isUngraded } from '../../utility/Constants'
@@ -90,11 +90,11 @@ export default ({ id }) => {
         success={success}
       />
 
-      <ErrorBanner>
+      <Toast>
         {showError
           ? 'There was an issue submitting. If this persists, please contact us on discord.'
           : null}
-      </ErrorBanner>
+      </Toast>
     </>
   )
 }

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -8,7 +8,7 @@ import github from '../assets/icons/github.svg'
 import { useAuth, googleSignIn, githubSignIn } from '../utility/Auth'
 import { DB_HACKATHON, FIREBASE_AUTH_ERROR } from '../utility/Constants'
 import { useLocation } from 'wouter'
-import ErrorBanner from '../components/ErrorBanner'
+import Toast from '../components/Toast'
 import { A } from '../components/Typography'
 import { copyText } from '../utility/Constants'
 
@@ -102,7 +102,7 @@ export default () => {
         </ButtonContainer>
         {DB_HACKATHON === 'LHD2021' && <A href="/">Return to Portal</A>}
       </Landing>
-      <ErrorBanner>{error ? handleAuthError(error.code, error.message) : null}</ErrorBanner>
+      <Toast>{error ? handleAuthError(error.code, error.message) : null}</Toast>
     </>
   )
 }

--- a/src/theme/ThemeProvider.js
+++ b/src/theme/ThemeProvider.js
@@ -50,7 +50,8 @@ const nwTheme = {
     secondaryBackgroundTransparent: '#FFB72Cbb', // before: #1D1B24bb
     secondaryBackground: '#051439',
     error: '#ff0033',
-    errorText: '#fff',
+    success: '#629F5D',
+    toastText: '#fff', // Color for text in toast messages (Toast.js)
     foreground: '#4F4A59',
     primary: '#FFB72C',
     default: '#BEBEBE',
@@ -92,7 +93,8 @@ const hackcampTheme = {
     secondaryBackgroundTransparent: '#1E4F5A',
     foreground: '#FFBC96',
     error: '#ff0033',
-    errorText: '#fff',
+    success: '#629F5D',
+    toastText: '#fff', // Color for text in toast messages (Toast.js)
     warning: '#FF8989',
     secondaryWarning: '#EF6C6C',
     primary: '#FFBC96',
@@ -133,7 +135,8 @@ const cmdfTheme = {
     secondaryBackgroundTransparent: '#B7C2B4',
     foreground: '#FFBC96',
     error: '#ff0033',
-    errorText: '#fff',
+    success: '#629F5D',
+    toastText: '#fff', // Color for text in toast messages (Toast.js)
     warning: '#FF8989',
     secondaryWarning: '#EF6C6C',
     primary: '#B95D1D',


### PR DESCRIPTION
## Description
Rewrote the existing ErrorBanner to be Toast, and added ability to specify whether it's a success or error toast. Currently defaults to Toast so that existing usage of the component doesn't change (this has been checked)

With this done, I've now set the toast to show up on successful actions in the project submission form, and it'll show for 3 seconds before the page is reloaded automatically.

![image](https://user-images.githubusercontent.com/5078356/149632931-0a3c3d06-3755-44ce-ae55-81066c6e084d.png)