### PR TITLE
Add ability to export projects CSV

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "firebase": "^7.17.1",
     "husky": "^4.3.0",
     "react": "^16.13.1",
+    "react-csv": "^2.2.1",
     "react-dom": "^16.13.1",
     "react-markdown": "^4.3.1",
     "react-scripts": "3.4.1",

--- a/src/containers/JudgingPanel.js
+++ b/src/containers/JudgingPanel.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { MoonLoader } from 'react-spinners'
 import styled from 'styled-components'
+import { CSVLink } from 'react-csv'
 import { projectsRef, submitGrade } from '../utility/firebase'
 import { Button, ToggleSwitch } from '../components/Input'
 import { H1, H3, P } from '../components/Typography'
@@ -15,6 +16,10 @@ const Columns = styled.div`
 `
 const Column = styled.div`
   margin: 1em;
+`
+const StyledCSVLink = styled(CSVLink)`
+  color: ${p => p.theme.colors.primary};
+  text-decoration: none;
 `
 
 const getStats = async () => {
@@ -169,6 +174,7 @@ const getGradedProjects = async (dropOutliers = 2) => {
 
 export default () => {
   const [gradedProjects, setGradedProjects] = useState([])
+  const [CSVProjectData, setCSVProjectData] = useState([])
   const [grades, setGrades] = useState([]) // Individual "grade" objects
   const [isLoading, setLoading] = useState(false)
   const [stats, setStats] = useState({
@@ -202,6 +208,17 @@ export default () => {
   useEffect(() => {
     setProjectsAndStats()
   }, [])
+
+  useEffect(() => {
+    const formattedProjects = gradedProjects.map(projects => {
+      const portalLink = window.location.origin // to support local development as well
+      return {
+        title: projects.title,
+        link: `${portalLink}/projects/${projects.id}`,
+      }
+    })
+    setCSVProjectData(formattedProjects)
+  }, [gradedProjects])
 
   const percentageAssigned = stats.total
     ? ((stats.assigned * 100) / (stats.total * PROJECTS_TO_JUDGE_COUNT)).toFixed(2)
@@ -245,6 +262,11 @@ export default () => {
         </Columns>
         <Button color="secondary" width="large" onClick={setProjectsAndStats}>
           Refresh Grades
+        </Button>
+        <Button color="secondary" width="large">
+          <StyledCSVLink data={CSVProjectData} filename={'projects.csv'} target="_blank">
+            Download CSV
+          </StyledCSVLink>
         </Button>
         <MoonLoader color="#fff" loading={isLoading} />
         {toggle.projectsGrades ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -8261,6 +8261,11 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
+react-csv@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-csv/-/react-csv-2.2.1.tgz#2ec723dd3ce8069269bffb3a95d968302fc87740"
+  integrity sha512-QdImVwsFQIUcOti2dJFTLnxZ8dW/q+DDpjTmD1m1UVBxh2OaEwIBg7PSGA71m7GQEEoz8M5BfvEc1rd7q8rgPw==
+
 react-dev-utils@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-10.2.1.tgz#f6de325ae25fa4d546d09df4bb1befdc6dd19c19"


### PR DESCRIPTION
## Description
Title ^

This is located in the judging admin page. Currently only exports title of the project and a link to the project page on Portal

![image](https://user-images.githubusercontent.com/5078356/149652787-c2a9f860-1a49-4354-ae82-f02a7c9ad749.png)

