### PR TITLE
cmd-f 2022 nits + schedule scroll

### DIFF
--- a/src/components/Schedule/Timeline.js
+++ b/src/components/Schedule/Timeline.js
@@ -43,6 +43,7 @@ const TimelineLabel = styled.span`
 
 const CurrentTime = ({ start, duration, numCols }) => {
   const [currentTime, setCurrentTime] = useState(Date.now())
+  const [scrolled, setScrolled] = useState(false)
   const hoursBetweenNowAndStart = (currentTime - start) / 60 / 60 / 1000
   const renderCurrentTime = 0 < hoursBetweenNowAndStart && hoursBetweenNowAndStart < duration
 
@@ -52,6 +53,22 @@ const CurrentTime = ({ start, duration, numCols }) => {
       clearInterval(interval)
     }
   }, [])
+
+  // Scroll to where the current time indicator is
+  // I use a timeout because for some reason window initially thinks its height is short, so
+  // the scroll maxes out at this point. Obviously we don't want to, so a small timeout here.
+  useEffect(() => {
+    if (!scrolled && hoursBetweenNowAndStart > 1) {
+      const timeout = setTimeout(() => {
+        const scrollHeight = 72 + hoursBetweenNowAndStart * HOUR_HEIGHT
+        window.scrollTo({ top: scrollHeight, behavior: 'smooth' })
+        setScrolled(true)
+      }, 500)
+      return () => {
+        clearTimeout(timeout)
+      }
+    }
+  }, [scrolled, hoursBetweenNowAndStart])
 
   return (
     renderCurrentTime && (

--- a/src/pages/ProjectView.js
+++ b/src/pages/ProjectView.js
@@ -69,6 +69,8 @@ const Project = ({ project }) => {
 
   const getDisplayName = linkKey => {
     switch (linkKey) {
+      case 'devpost':
+        return 'Devpost'
       case 'youtube':
         return 'YouTube'
       case 'sourceCode':


### PR DESCRIPTION
![](https://media.giphy.com/media/10LKovKon8DENq/giphy.gif)

## Description
Added a case for devpost links in project views so that it doesn't show up as a long ugly link
<img width="651" alt="image" src="https://user-images.githubusercontent.com/5078356/156900165-620a095e-ffa3-4b70-b959-927abfca834c.png">

Also finally added a scroll to current time in schedule :))) lmk if you can think of a cleaner implementation, but this is what I came up with
