### PR TITLE
updated submissions process for hackcamp

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,7 @@ import { APPLICATION_STATUS, DB_COLLECTION, DB_HACKATHON, IS_DEVICE_IOS } from '
 import notifications from './utility/notifications'
 import { AuthProvider, getRedirectUrl, useAuth } from './utility/Auth'
 import { HackerApplicationProvider, useHackerApplication } from './utility/HackerApplicationContext'
+import Area51 from './pages/Area51'
 
 // only notify user if announcement was created within last 5 secs
 const notifyUser = announcement => {
@@ -249,6 +250,9 @@ function App() {
           </AuthPageRoute>
           <AdminAuthPageRoute path="/judging/admin">
             <JudgingAdmin />
+          </AdminAuthPageRoute>
+          <AdminAuthPageRoute path="/area51">
+            <Area51 />
           </AdminAuthPageRoute>
           <Route path="/judging/view/:id" component={JudgingViewContainer} />
           <Route path="/projects" component={GalleryContainer} />

--- a/src/components/Judging/Admin/Table.js
+++ b/src/components/Judging/Admin/Table.js
@@ -127,7 +127,6 @@ const RemoveButton = ({ onRemove }) => {
 }
 
 export const GradeTable = ({ data, onRemove }) => {
-  console.log(data)
   const formattedData = data?.map(row => {
     const projectLink = `/projects/${row.id}`
     return [

--- a/src/components/Judging/Admin/Table.js
+++ b/src/components/Judging/Admin/Table.js
@@ -127,6 +127,7 @@ const RemoveButton = ({ onRemove }) => {
 }
 
 export const GradeTable = ({ data, onRemove }) => {
+  console.log(data)
   const formattedData = data?.map(row => {
     const projectLink = `/projects/${row.id}`
     return [

--- a/src/components/Judging/Submission.js
+++ b/src/components/Judging/Submission.js
@@ -101,12 +101,12 @@ export default ({ project, reportCallback }) => {
     <>
       <H1>Project Submission</H1>
       <H3>Team Members: {project.teamMembers.map(member => member.name).join(', ')}</H3>
-      <H3>
+      {/* <H3>
         Sponsor Prizes:{' '}
         {project.sponsorPrizes[0]
           ? project.sponsorPrizes.join(', ')
           : "Didn't apply for sponsor prizes"}
-      </H3>
+      </H3> */}
       <Columns>
         <Column>
           <JudgingCard {...project} buttonLabel="View project" href={'projects/' + project.id} />

--- a/src/components/Judging/Submission.js
+++ b/src/components/Judging/Submission.js
@@ -97,10 +97,14 @@ const FeedbackCard = ({ feedback, reportCallback }) => {
 
 export default ({ project, reportCallback }) => {
   const gradeCount = Object.keys(project.grades ?? {}).length
+
+  console.log(project)
+  if (!project?.href) return <></>
+
   return (
     <>
       <H1>Project Submission</H1>
-      <H3>Team Members: {project.teamMembers.map(member => member.name).join(', ')}</H3>
+      <H3>Team Members: {project?.teamMembers?.map(member => member.name).join(', ')}</H3>
       {/* <H3>
         Sponsor Prizes:{' '}
         {project.sponsorPrizes[0]

--- a/src/components/Judging/SubmissionForm.js
+++ b/src/components/Judging/SubmissionForm.js
@@ -12,7 +12,7 @@ import {
   validateURL,
 } from '../../utility/Validation'
 import { getSponsorPrizes } from '../../utility/firebase'
-import { findElement } from '../../utility/utilities'
+// import { findElement } from '../../utility/utilities' // to fix no-unused-vars; commented out charities
 
 const FormSection = styled.div`
   display: flex;
@@ -110,13 +110,13 @@ export default ({
   const [draftStatus, setDraftStatus] = useState(project.draftStatus || 'draft')
   const [errors, setErrors] = useState({})
 
-  const charities = [
-    { value: 'CMHA', label: 'Canadian Mental Health Association' },
-    { value: 'BCCH', label: "BC Children's Hospital" },
-    { value: 'DEWC', label: "Downtown Eastside Women's Centre" },
-    { value: 'GWC', label: 'Girls Who Code' },
-    { value: 'SRM', label: 'Sunrise Movement' },
-  ]
+  // const charities = [
+  //   { value: 'CMHA', label: 'Canadian Mental Health Association' },
+  //   { value: 'BCCH', label: "BC Children's Hospital" },
+  //   { value: 'DEWC', label: "Downtown Eastside Women's Centre" },
+  //   { value: 'GWC', label: 'Girls Who Code' },
+  //   { value: 'SRM', label: 'Sunrise Movement' },
+  // ]
 
   // Fetch list of sponsor prizes from Firebase
   useEffect(() => {
@@ -192,10 +192,10 @@ export default ({
       if (!member.email && (isRequired || member.name || member.discord)) {
         newErrors[`member${index + 1}Email`] = 'Please enter a valid email'
       }
-      if (!member.discord && (isRequired || member.name || member.email)) {
-        newErrors[`member${index + 1}Discord`] =
-          'Please enter a valid Discord username (eg. username#1234)'
-      }
+      // if (!member.discord && (isRequired || member.name || member.email)) {
+      //   newErrors[`member${index + 1}Discord`] =
+      //     'Please enter a valid Discord username (eg. username#1234)'
+      // }
       if (member.email && !validateEmail(member.email)) {
         newErrors[`member${index + 1}Email`] = 'Please enter a valid email'
       }
@@ -232,16 +232,16 @@ export default ({
     }
 
     // Validate charity selection
-    if (!charityChoice) {
-      newErrors.charity = 'Please select a charity'
-    }
+    // if (!charityChoice) {
+    //   newErrors.charity = 'Please select a charity'
+    // }
 
     setErrors(newErrors)
 
     // Remove incomplete member objects
     const membersArray = [...members]
     const filteredMembers = membersArray.filter(member => {
-      return member?.name && member?.email && member?.discord
+      return member?.name && member?.email // && member?.discord
     })
 
     // If no errors, submit
@@ -322,7 +322,8 @@ export default ({
           onChange={e => setLinks({ ...links, other: e.target.value })}
         />
       </FormSection>
-      <FormSection>
+      {/* Charities for CMD-F */}
+      {/* <FormSection>
         <div>
           <Label>Charity Choice</Label>
           <Required />
@@ -332,8 +333,7 @@ export default ({
             is done so as to emphasize cmd-f's mission of focusing on the learning and growth aspect
             of hackathons!
           </P>
-        </div>
-        <div>
+        </div> <div>
           <Dropdown
             options={charities}
             placeholder={
@@ -345,7 +345,7 @@ export default ({
             isValid
           />
         </div>
-      </FormSection>
+      </FormSection> */}
       {sponsorPrizes && (
         <FormSection>
           <Label>Sponsor Prizes</Label>
@@ -391,7 +391,8 @@ export default ({
                 errorMsg={errors?.[`member${index + 1}Email`]}
                 onChange={e => updateMember(index, 'email', e.target.value)}
               />
-              <TextInputWithField
+              {/* HackCamp 2022 uses slack */}
+              {/* <TextInputWithField
                 fieldName="Discord username"
                 value={member?.discord}
                 placeholder="username#1234"
@@ -399,7 +400,7 @@ export default ({
                 invalid={errors?.[`member${index + 1}Discord`]}
                 errorMsg={errors?.[`member${index + 1}Discord`]}
                 onChange={e => updateMember(index, 'discord', e.target.value)}
-              />
+              /> */}
             </TeamMember>
           ))}
         </MemberList>

--- a/src/components/Judging/ViewProject.js
+++ b/src/components/Judging/ViewProject.js
@@ -50,6 +50,7 @@ const StyledTextArea = styled(TextArea)`
 
 const RightButton = styled(Button)`
   float: right;
+  white-space: nowrap;
 `
 
 const StyledMessage = styled(Message)`

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -196,7 +196,7 @@ export default ({
     ],
     // Information
     information: [
-      { location: '/discord-bot', text: 'Discord Bot' },
+      // { location: '/discord-bot', text: 'Discord Bot' },
       { location: '/faq', text: 'FAQ' },
     ],
   }

--- a/src/containers/Landing/Footer.js
+++ b/src/containers/Landing/Footer.js
@@ -82,8 +82,12 @@ export default () => {
   return (
     <>
       <SponsorsContainer>
-        <H1 size="1.5em">Sponsored by</H1>
-        <LogoContainer>{SponsorList}</LogoContainer>
+        {sponsors.length > 0 && (
+          <>
+            <H1 size="1.5em">Sponsored by</H1>
+            <LogoContainer>{SponsorList}</LogoContainer>
+          </>
+        )}
       </SponsorsContainer>
       <SocialIconContainer>
         <Icon href={SOCIAL_LINKS.FB} icon="facebook" brand size="2x" />
@@ -92,7 +96,7 @@ export default () => {
         <Icon href={SOCIAL_LINKS.TW} icon="twitter" brand size="2x" />
       </SocialIconContainer>
       <CopyrightBlurb>
-        Copyright &copy; 2020 <A href={SOCIAL_LINKS.WEBSITE}>nwPlus</A>
+        Copyright &copy; {new Date().getFullYear()} <A href={SOCIAL_LINKS.WEBSITE}>nwPlus</A>
       </CopyrightBlurb>
     </>
   )

--- a/src/pages/Area51.js
+++ b/src/pages/Area51.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Button } from '../components/Input'
+import { setWhitelist } from '../utility/firebase'
+
+export default () => {
+  return (
+    <div>
+      <Button
+        color="secondary"
+        width="flex"
+        onClick={() => {
+          setWhitelist()
+        }}
+      >
+        Add current whitelist
+      </Button>
+    </div>
+  )
+}

--- a/src/pages/Charcuterie.js
+++ b/src/pages/Charcuterie.js
@@ -47,6 +47,8 @@ const toggleTheme = () => {
   const oldTheme = window.localStorage.getItem('localTheme')
   if (oldTheme === 'nwTheme') {
     window.localStorage.setItem('localTheme', 'cmdfTheme')
+  } else if (oldTheme === 'cmdfTheme') {
+    window.localStorage.setItem('localTheme', 'hackcampTheme')
   } else {
     window.localStorage.setItem('localTheme', 'nwTheme')
   }

--- a/src/pages/Submission.js
+++ b/src/pages/Submission.js
@@ -60,6 +60,8 @@ export default () => {
     return <Loading />
   }
 
+  console.log(isJudgingReleased, isSubmissionsOpen)
+
   if (isJudgingReleased) {
     return (
       <ViewSubmission

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -12,7 +12,7 @@ export const copyText = Object.freeze({
   hackathonNameShort: 'HackCamp',
 })
 
-export const PROJECTS_TO_JUDGE_COUNT = 5
+export const PROJECTS_TO_JUDGE_COUNT = 4
 export const MAX_CHARACTERS_IN_DESCRIPTION = 100
 
 export const NOTIFICATION_PERMISSIONS = Object.freeze({

--- a/src/utility/firebase.js
+++ b/src/utility/firebase.js
@@ -42,6 +42,46 @@ export const getLivesiteDoc = callback => {
   })
 }
 
+// -----------------------------------------------------
+// TODO: Delete temporary code that whitelists users that have RSVP'd (all the commented bars)
+export const setWhitelist = async () => {
+  let batch = db.batch()
+
+  let whitelisted =
+    'ryanzhou2004@gmail.com,sunyiran0817@gmail.com,devmwang@icloud.com,mariesamantha.f@gmail.com,wuchuoxi@gmail.com,ethanngu19@gmail.com,eunhocj93@gmail.com,billy131lam@gmail.com,rishabhg260203@gmail.com,wcao2012@gmail.com,vikimho@gmail.com,racheln0519@gmail.com,ekam.13dhanoa@gmail.com,shibuanshu@gmail.com,caris.h.tin@gmail.com,ynwinubc24@gmail.com,kylieakrueger@gmail.com,stephenqiao123@gmail.com,oceannanguyen@gmail.com,mtang78@student.ubc.ca,david-guo@live.ca,kevinhu738@gmail.com,acl.aeng@gmail.com,tl0226yn@gmail.com,wenjiejin00@gmail.com,meganong1@gmail.com,dannieko02@gmail.com,wendyngan710@gmail.com,kevinshiao5@gmail.com,erichsieh25@gmail.com,racheljune2004@gmail.com,illing.noel@gmail.com,mominkas@student.ubc.ca,hanatutak@gmail.com,tracy.la829@gmail.com,danirenn16@gmail.com,jessieshengyj@gmail.com,josephine.sshuang@gmail.com,ericleung147258369@hotmail.com,chanemily24@gmail.com,sallyhan062@gmail.com,henryshkim@hotmail.com,patty.tanch@gmail.com,suhailkhalil2002@gmail.com,pratham.bansal2112@gmail.com,rafaykhurram@live.com,mpaknys@icloud.com,ytaghavi@yahoo.com,matthewyungisworking@gmail.com,noornaila04@gmail.com,brnyng926@gmail.com,aaronlam111@gmail.com,nadellavamsi06@gmail.com,kashishgarg247@gmail.com,nsjlee33@hotmail.com,sam1128van@gmail.com,eric.shuai88@gmail.com,jameswu0414@gmail.com,afifmv1@gmail.com,dalmia.kavya@gmail.com,hongcs2002@gmail.com,rayn.friar@gmail.com,tliu024@student.ubc.ca,tomanh2104@gmail.com,joycai.0205@gmail.com,andrewfeng2014@gmail.com,alexjeon246@gmail.com,aprameyaithal@gmail.com,divyharjunsingh@gmail.com,hthlai@student.ubc.ca,ashishpanda0415@gmail.com,tristontsui@gmail.com,kylema.1042@gmail.com,rohs44893@g.skku.edu,kmryn410@gmail.com,kashish1609@gmail.com,rwu20@student.ubc.ca,liujenny.l98@gmail.com,juliasangster@hotmail.com,zaidt221325@gmail.com,alyoawesome100@gmail.com,myhou0720@gmail.com,rowelsabahat15@gmail.com,zhoukev12@gmail.com,elenaopenworld@gmail.com,gabrielrdelarosa@gmail.com,williamtianyugao@gmail.com,pranjalgupta2802@gmail.com,mskent@live.ca,etrinh26@gmail.com,gsthanh@student.ubc.ca,karenagustino12@gmail.com,sunveerx@gmail.com,zhangyuzhelily@gmail.com,kellyyyxi@gmail.com,defneran@gmail.com,celinechen1114@gmail.com,salman_khan2001xx@hotmail.com,colin.cchn@gmail.com,britneyng1@gmail.com,dgmurgulet@gmail.com,wendygreening@telus.net,charliemchen@yahoo.com,li.kevin0203@gmail.com,briann.wong@hotmail.com,janieholzmann@gmail.com,wangowen02@gmail.com,rdmnr@protonmail.com,terrychou_28@hotmail.com,michaelfromyeg@gmail.com,amy34268@gmail.com,anicamok@gmail.com,nimanourozy@gmail.com,oltimaloku555@gmail.com,lindachu719@gmail.com,allantan.zf@gmail.com,hannah.Wong2021@gmail.com,timma0330@gmail.com,rxluo1202@gmail.com,sammishih04@gmail.com,echomaria98123@gmail.com,4ngelalucas@gmail.com,123.roychen@gmail.com,troy_64@telus.net,chloe.m.van@gmail.com,remembria.me@gmail.com,william_gao0206@hotmail.com,timmychieng@gmail.com,gordonch99@gmail.com,williamsunedu1617@gmail.com,alexwu120203@gmail.com,nokia.methasit@gmail.com,justinn.tangg@gmail.com,katherine2014lub@gmail.com,hcpc215@gmail.com,yuqing_ma98@163.com,scenery@student.ubc.ca,namazifardshadan@gmail.com,everettubc2002@gmail.com,michelleli11220@gmail.com,lewdanielyang@gmail.com,leila.gazizova2003@gmail.com,shivamkataria1000@gmail.com,jeffkim7@hotmail.com,alisonh24jsyk@gmail.com,callumoriley@gmail.com,aneesh.bulusu@gmail.com,charity.grey1@gmail.com,jess.c.zhou@gmail.com,gfzting@gmail.com,clarapark0808@gmail.com,chunwong@student.ubc.ca,napat.luan@gmail.com,lykawangg@gmail.com,jackwstwang@gmail.com'
+  let whitelistedArr = whitelisted.split(',')
+
+  for (let i = 0; i < whitelistedArr.length; i++) {
+    batch.set(
+      db.collection(DB_COLLECTION).doc(DB_HACKATHON).collection('Whitelist').doc(whitelistedArr[i]),
+      {}
+    )
+  }
+
+  batch.commit().then(() => {
+    alert('uploaded successfully')
+  })
+}
+// -----------------------------------------------------
+
+// -----------------------------------------------------
+export const getWhitelisted = async () => {
+  // db.collection('Hackathons').doc('HackCamp2022').collection('Whitelist')
+  const whitelisted = []
+  await db
+    .collection(DB_COLLECTION)
+    .doc(DB_HACKATHON)
+    .collection('Whitelist')
+    .get()
+    .then(querySnapshot => {
+      querySnapshot.forEach(doc => {
+        whitelisted.push(doc.id)
+      })
+    })
+  return whitelisted
+}
+// -----------------------------------------------------
+
 const createNewApplication = async user => {
   analytics.logEvent(ANALYTICS_EVENTS.signup, { userId: user.uid })
   const userId = {
@@ -71,7 +111,7 @@ const createNewApplication = async user => {
     submittedProject: '',
   }
 
-  const newApplication = {
+  let newApplication = {
     ...HACKER_APPLICATION_TEMPLATE,
     basicInfo: {
       ...HACKER_APPLICATION_TEMPLATE.basicInfo,
@@ -81,6 +121,23 @@ const createNewApplication = async user => {
     ...userId,
     ...judging,
   }
+
+  // -----------------------------------------------------
+  // If not whitelisted, no
+  const whitelisted = await getWhitelisted()
+  if (whitelisted.includes(user.email)) {
+    // good to go
+    newApplication = {
+      ...newApplication,
+      status: {
+        applicationStatus: 'accepted',
+        responded: true,
+        attending: true,
+      },
+    }
+    // else, the default application template will block them from submissions -> redirect to "Applications for this hackathon are closed"
+  }
+  // -----------------------------------------------------
 
   await applicantsRef.doc(user.uid).set(newApplication)
 }

--- a/src/utility/utilities.js
+++ b/src/utility/utilities.js
@@ -71,7 +71,7 @@ export const getYoutubeThumbnail = link => {
 export const formatProject = project => {
   return {
     ...project,
-    imgUrl: getYoutubeThumbnail(project.links.youtube),
+    imgUrl: getYoutubeThumbnail(project?.links?.youtube || ''),
     href: project.devpostUrl,
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes! Include motivation, changes you made, screenshots/video if applicable -->

Tested out + got peer judging ready for HC 2022

- Commented out to remove Charity selection for project submission:
Lines 15, 113-119, 234-237 in `src/Components/Judging/SubmissionForm.js`
- Commented out to remove Discord Username for project submission:
Lines 195-198, partial 244 in `src/Components/Judging/SubmissionForm.js`
- Commented out Sponsor Prizes in submission viewing:
Lines 104-109 in `src/Components/Judging/Submission.js`
- Updated landing screen for closed registration:
  - Copyright year is always the current year (lol)
  - No 'Sponsored By' if sponsors array is empty
- Decreased amount of projects to judge in `src/utility/Constant.js`: PROJECTS_TO_JUDGE_COUNT = 5 -> 4

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
Notes:
- Going into /submissions page as an organizer (possible) or as a hacker who hasn't visited the tab while submissions are open (submissions are auto-generated when visited) will give an error (page tries to display null information)
- For organizers, in the Judging Admin page: Total project graded % is calculated with the PROJECTS_TO_JUDGE_COUNT constant -- having less projects for all teams to grade 4 will give an unintuitive percentage
- Grades can also be NaN in the Projects view if it hasn't been graded by enough (I think?)

