### PR TITLE
change handling of zero duration events

### DIFF
--- a/src/components/Schedule/Schedule.js
+++ b/src/components/Schedule/Schedule.js
@@ -108,11 +108,20 @@ export default ({ events, hackathonStart, hackathonEnd }) => {
 
           // set duration of event
           const duration = msToHours(new Date(event.endTime) - new Date(event.startTime))
-          event.duration = duration
+          const isZeroDurationEvent = duration === 0
+
+          // if zero duration event, set event duration to be 0.5 (30 minutes) because 0 duration events end up being too tall
+          event.duration = isZeroDurationEvent ? 0.5 : duration
 
           accumulator.push(event)
           usedEvents.push(event)
-          latestTime = new Date(event.endTime)
+
+          let newLatestTime = new Date(event.endTime)
+
+          // if zero duration event, set new latestTime = latestTime + 30 to avoid overlaps
+          latestTime = isZeroDurationEvent
+            ? new Date(newLatestTime.setMinutes(newLatestTime.getMinutes() + 30))
+            : newLatestTime
         }
         return accumulator
       }, [])


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/56494179/213565464-28c8c173-9132-4aa1-8a99-2857b022f4f3.png)

^ 0 duration events are too wide so set them to be duration 0.5

however, as a result of this, the event scheduling placement algorithm causes overlaps like below:
![image](https://user-images.githubusercontent.com/56494179/213565238-63afc596-00f0-416b-af84-fcfac88b213f.png)
because while the duration (how height is calculated) is getting set to 0.5, latestTime incorrectly thinks it is 30 minutes earlier than it should be. latestTime is now getting set in accordance to zero duration events

what it looks like after changes:

![image](https://user-images.githubusercontent.com/56494179/213562771-8604aaed-324d-4460-9311-0d5c9760880c.png)
