### PR TITLE
Input validation bug fix

### DIFF
--- a/src/components/ApplicationForm/BasicInfo.js
+++ b/src/components/ApplicationForm/BasicInfo.js
@@ -765,7 +765,7 @@ export default ({ refs, errors, formInputs, onChange }) => (
                   ethnicity: { ...formInputs.ethnicity, [key]: !val },
                 })
               }
-              customRef={key === 'ethnicity' ? refs['ethnicityRef'] : null}
+              customRef={refs['ethnicityRef']}
             />
           ))}
       <br />

--- a/src/components/ApplicationForm/BasicInfo.js
+++ b/src/components/ApplicationForm/BasicInfo.js
@@ -568,7 +568,7 @@ export default ({ refs, errors, formInputs, onChange }) => (
           })
         }
         isValid={!errors?.graduation}
-        customRef={refs['graduation']}
+        customRef={refs['graduationRef']}
       />
     </FormSpacing>
 

--- a/src/containers/Application/Part1.js
+++ b/src/containers/Application/Part1.js
@@ -80,10 +80,12 @@ export default () => {
   const handleNavigation = async href => {
     await save()
     if (href === '/application/part-2') {
+      // question is false if it is filled out
       const newErrors = validate(application.basicInfo)
       if (checkForError(newErrors)) {
         for (let question of questionsByOrder) {
           if (newErrors[question]) {
+            // redirects the user to the question
             refs[`${question}Ref`].current.focus()
             break
           }

--- a/src/containers/Application/Part1.js
+++ b/src/containers/Application/Part1.js
@@ -86,7 +86,6 @@ export default () => {
         for (let question of questionsByOrder) {
           if (newErrors[question]) {
             // redirects the user to the question
-            console.log(question + 'Ref')
             refs[`${question}Ref`].current.focus()
             break
           }

--- a/src/containers/Application/Part1.js
+++ b/src/containers/Application/Part1.js
@@ -86,6 +86,7 @@ export default () => {
         for (let question of questionsByOrder) {
           if (newErrors[question]) {
             // redirects the user to the question
+            console.log(question + 'Ref')
             refs[`${question}Ref`].current.focus()
             break
           }


### PR DESCRIPTION
## Description
Error: clicking next when q7, 13 or 15 are unfilled resulted in an error

solution:
- q7: customRef={refs['graduation']} --> customRef={refs['graduation**Ref**']}
missing "Ref" at the end of the question, so could not find where to redirect the user to when the question is missing an answer
- q13: also customRef issue, removed one of the logic thingies (see commit for more detail) causing it to not chose the correct ref
- q15: no error

