### PR TITLE
add charity options for HC2023

### DIFF
--- a/src/components/Judging/SubmissionForm.js
+++ b/src/components/Judging/SubmissionForm.js
@@ -342,14 +342,14 @@ export default ({
         <div>
           <Label color="white">Charity Choice</Label>
           <Required />
+        </div>
+        <div>
           <P>
             Every project submitted at HackCamp 2023, regardless of completion, will be eligible for
             a $10 donation to the charity of your choice from a curated list by the HackCamp team!
             This is done so as to emphasize HackCamp's mission of focusing on the learning and
             growth aspect of hackathons!
           </P>
-        </div>
-        <div>
           <Dropdown
             options={charities}
             placeholder={

--- a/src/components/Judging/SubmissionForm.js
+++ b/src/components/Judging/SubmissionForm.js
@@ -2,14 +2,7 @@ import React, { useEffect } from 'react'
 import { useState } from 'react'
 import styled from 'styled-components'
 import { Button, Select, TextArea, TextInput, Dropdown } from '../Input'
-import {
-  ErrorSpan as Required,
-  ErrorMessage,
-  H1,
-  H3,
-  // P,
-  Label,
-} from '../Typography'
+import { ErrorSpan as Required, ErrorMessage, H1, H3, P, Label } from '../Typography'
 import Toast from '../Toast'
 import {
   validateDiscord,
@@ -19,7 +12,7 @@ import {
   validateURL,
 } from '../../utility/Validation'
 import { getSponsorPrizes } from '../../utility/firebase'
-// import { findElement } from '../../utility/utilities' // to fix no-unused-vars; commented out charities
+import { findElement } from '../../utility/utilities'
 
 const FormSection = styled.div`
   display: flex;
@@ -62,6 +55,15 @@ const ButtonContainer = styled.div`
   display: flex;
   justify-content: space-between;
 `
+
+const charities = [
+  { value: "GiveWell's Top Charities Fund", label: "GiveWell's Top Charities Fund" },
+  {
+    value: 'British Columbia Centre for Ability Association',
+    label: 'British Columbia Centre for Ability Association',
+  },
+  { value: 'Covenant House', label: 'Covenant House' },
+]
 
 const TextInputWithField = ({
   fieldName,
@@ -112,7 +114,7 @@ export default ({
   const [links, setLinks] = useState(project.links || {})
   const [sponsorPrizes, setSponsorPrizes] = useState([])
   const [mentorNomination, setMentorNomination] = useState(project.mentorNomination || '')
-  // const [charityChoice, setCharityChoice] = useState(project.charityChoice || '')
+  const [charityChoice, setCharityChoice] = useState(project.charityChoice || '')
   const [selectedPrizes, setSelectedPrizes] = useState(project.sponsorPrizes || [])
   const [draftStatus, setDraftStatus] = useState(project.draftStatus || 'draft')
   const [errors, setErrors] = useState({})
@@ -141,7 +143,7 @@ export default ({
     setDescription(project.description || '')
     setLinks(project.links || {})
     setMentorNomination(project.mentorNomination || '')
-    // setCharityChoice(project.charityChoice || '')
+    setCharityChoice(project.charityChoice || '')
     setSelectedPrizes(project.sponsorPrizes || [])
     setDraftStatus(project.draftStatus || 'draft')
 
@@ -239,9 +241,9 @@ export default ({
     }
 
     // Validate charity selection
-    // if (!charityChoice) {
-    //   newErrors.charity = 'Please select a charity'
-    // }
+    if (!charityChoice) {
+      newErrors.charity = 'Please select a charity'
+    }
 
     setErrors(newErrors)
 
@@ -259,7 +261,7 @@ export default ({
         teamMembers: filteredMembers,
         links,
         sponsorPrizes: selectedPrizes,
-        // charityChoice,
+        charityChoice,
         mentorNomination,
         uid: project.uid,
         draftStatus,
@@ -336,18 +338,18 @@ export default ({
           onChange={e => setMentorNomination(e.target.value)}
         />
       </FormSection>
-      {/* Charities for CMD-F */}
-      {/* <FormSection>
+      <FormSection>
         <div>
           <Label color="white">Charity Choice</Label>
           <Required />
           <P>
-            Every project submitted at cmd-f 2022, regardless of completion, will be eligible for a
-            $20 donation to the charity of your choice from a curated list by the cmd-f team! This
-            is done so as to emphasize cmd-f's mission of focusing on the learning and growth aspect
-            of hackathons!
+            Every project submitted at HackCamp 2023, regardless of completion, will be eligible for
+            a $10 donation to the charity of your choice from a curated list by the HackCamp team!
+            This is done so as to emphasize HackCamp's mission of focusing on the learning and
+            growth aspect of hackathons!
           </P>
-        </div> <div>
+        </div>
+        <div>
           <Dropdown
             options={charities}
             placeholder={
@@ -356,10 +358,11 @@ export default ({
             value={findElement(charities, 'value', charityChoice)}
             isSearchable={false}
             onChange={inputValue => setCharityChoice(inputValue.value)}
-            isValid
+            isValid={!errors?.charity}
+            errorMessage={errors?.charity}
           />
         </div>
-      </FormSection> */}
+      </FormSection>
       {sponsorPrizes && (
         <FormSection>
           <Label color="white">Sponsor Prizes</Label>

--- a/src/components/Judging/SubmissionForm.js
+++ b/src/components/Judging/SubmissionForm.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import { useState } from 'react'
 import styled from 'styled-components'
 import { Button, Select, TextArea, TextInput, Dropdown } from '../Input'
-import { ErrorSpan as Required, ErrorMessage, H1, H3, P, Label } from '../Typography'
+import { ErrorSpan as Required, ErrorMessage, H1, H3, P, Label, A } from '../Typography'
 import Toast from '../Toast'
 import {
   validateDiscord,
@@ -41,6 +41,15 @@ const TeamMember = styled.div`
 const StyledH3 = styled(H3)`
   margin: 0;
   text-transform: uppercase;
+`
+
+const StyledA = styled(A)`
+  color: white;
+  border-color: white;
+
+  &:hover {
+    color: ${p => p.theme.colors.tertiaryHover};
+  }
 `
 
 const FieldName = styled.div`
@@ -349,6 +358,17 @@ export default ({
             a $10 donation to the charity of your choice from a curated list by the HackCamp team!
             This is done so as to emphasize HackCamp's mission of focusing on the learning and
             growth aspect of hackathons!
+          </P>
+          <P style={{ marginTop: '8px' }}>
+            Click &#8202;
+            <StyledA
+              target="_blank"
+              rel="noreferrer noopener"
+              href="https://nwplus.notion.site/PUBLIC-Charities-2716e8e72c7742b082ec06c8c463965f?pvs=4"
+            >
+              here
+            </StyledA>
+            &#8202; to learn more about each charity.
           </P>
           <Dropdown
             options={charities}


### PR DESCRIPTION
couple of notes:
- very basic implementation, used a required dropdown (not sure if we wanted this to be required field?) it saves in the database as the field 'charityChoice', lmk if there's any other action items
- charities hard coded, not sure if there was a way in admin portal to set up charities in the DB. also made the value/label the same
- if we want to add a way for people to view a description of each of the charities (e.g. a tooltip), i could do that
