### PR TITLE
Pull schedule dates from Firebase

### DIFF
--- a/src/components/Schedule/Timeline.js
+++ b/src/components/Schedule/Timeline.js
@@ -79,6 +79,19 @@ const CurrentTime = ({ start, duration, numCols }) => {
 
 export const TimelineColumn = ({ hackathonStart, duration, numCols }) => {
   duration = Math.floor(Math.max(0, duration))
+  const dayOneDate = hackathonStart.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+  const dayTwoDate = new Date(hackathonStart.getTime() + 24 * 60 * 60 * 1000).toLocaleDateString(
+    'en-US',
+    {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }
+  )
   return (
     <TimelineColumnContainer duration={duration}>
       <CurrentTime start={hackathonStart} duration={duration} numCols={numCols} />
@@ -90,7 +103,7 @@ export const TimelineColumn = ({ hackathonStart, duration, numCols }) => {
           return (
             <TimelineBlock key={i}>
               <TimelineLabel hourOffset={i}>
-                <strong>November 18th, 2023</strong>
+                <strong>{dayOneDate}</strong>
                 <br />
                 {label}
               </TimelineLabel>
@@ -104,7 +117,7 @@ export const TimelineColumn = ({ hackathonStart, duration, numCols }) => {
           return (
             <TimelineBlock key={i}>
               <TimelineLabel hourOffset={i}>
-                <strong>November 19th, 2023</strong>
+                <strong>{dayTwoDate}</strong>
                 <br />
                 {label}
               </TimelineLabel>

--- a/src/containers/Schedule.js
+++ b/src/containers/Schedule.js
@@ -11,10 +11,10 @@ export default () => {
 
   useEffect(() => {
     const unsubscribe = livesiteDocRef.onSnapshot(doc => {
-      const d = doc.data()
-      if (d) {
-        setStart(new Date(d.hackathonStart))
-        setEnd(new Date(d.hackathonEnd))
+      const data = doc.data()
+      if (data) {
+        setStart(new Date(data.hackathonStart))
+        setEnd(new Date(data.hackathonEnd))
       }
     })
     return unsubscribe


### PR DESCRIPTION
## Description

Pulls schedule dates from Firebase instead of having them hardcoded.

## Other considerations

Changed to short date format so it's a bit easier to see the day number (see screenshot), if you think a different format is better lmk
