### PR TITLE
Hackathon context + routing changes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "semi": false,
   "singleQuote": true,
   "printWidth": 100,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "quoteProps": "consistent"
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Redirect, Route, Switch } from 'wouter'
+import { Redirect, Route, Switch, useLocation, useRouter, Router, Link } from 'wouter'
 import Form from './components/ApplicationForm'
 import Navbar from './components/Navbar'
 import Page from './components/Page'
@@ -9,10 +9,8 @@ import {
   ApplicationForm,
   ApplicationReview,
   Charcuterie,
-  // DiscordBot,
   Faq,
   Gallery,
-  // GettingStarted,
   Home,
   Livestream,
   Judging,
@@ -25,16 +23,23 @@ import {
   Sponsors,
   Submission,
 } from './pages'
-// import Area51 from './pages/Area51'
 import GlobalStyle from './theme/GlobalStyle'
 import ThemeProvider from './theme/ThemeProvider'
-import HackathonProvider from './utility/HackathonProvider'
 import { AuthProvider, getRedirectUrl, useAuth } from './utility/Auth'
-import { APPLICATION_STATUS, DB_COLLECTION, DB_HACKATHON, IS_DEVICE_IOS } from './utility/Constants'
+import {
+  APPLICATION_STATUS,
+  DB_COLLECTION,
+  DB_HACKATHON,
+  IS_DEVICE_IOS,
+  VALID_HACKATHONS,
+} from './utility/Constants'
 import { HackerApplicationProvider, useHackerApplication } from './utility/HackerApplicationContext'
 import { db, getAnnouncement, getLivesiteDoc } from './utility/firebase'
 import notifications from './utility/notifications'
 import AnnouncementToast from './components/AnnouncementToast'
+import HackathonProvider, { useHackathon } from './utility/HackathonProvider'
+import Landing from './containers/Landing'
+import { A } from './components/Typography'
 
 const PageRoute = ({ path, children }) => {
   const [livesiteDoc, setLivesiteDoc] = useState(null)
@@ -51,19 +56,18 @@ const PageRoute = ({ path, children }) => {
   )
 }
 
-// Authenticate for only applicants that have been accepted
 const AuthPageRoute = ({ path, children }) => {
   const { isAuthed, user } = useAuth()
   if (!isAuthed) {
     return (
       <Route path={path}>
-        <Redirect to="/login" />
+        <Redirect to="~/login" />
       </Route>
     )
   }
   return (
     <Route path={path}>
-      {user?.status === APPLICATION_STATUS.accepted ? (
+      {user?.status !== APPLICATION_STATUS.accepted ? (
         <Page>{children}</Page>
       ) : (
         <Redirect to="/application/closed" />
@@ -72,8 +76,9 @@ const AuthPageRoute = ({ path, children }) => {
   )
 }
 
-const ApplicationInProgressRoute = ({ name, handleLogout, path, children, theme }) => {
+const ApplicationInProgressRoute = ({ name, handleLogout, path, children }) => {
   const { isAuthed, user, logout } = useAuth()
+
   return isAuthed ? (
     <Route path={path}>
       <Navbar
@@ -84,29 +89,31 @@ const ApplicationInProgressRoute = ({ name, handleLogout, path, children, theme 
       </Navbar>
     </Route>
   ) : (
-    <Redirect to="/login" />
+    <Redirect to="~/login" />
   )
 }
 
 const NoAuthRoute = ({ path, children }) => {
   const { isAuthed, user } = useAuth()
+  const { activeHackathon } = useHackathon()
+
   return (
     <Route path={path}>
-      {!isAuthed ? <>{children}</> : <Redirect to={getRedirectUrl(user.redirect)} />}
+      {!isAuthed ? children : <Redirect to={getRedirectUrl(user.redirect, activeHackathon)} />}
     </Route>
   )
 }
 
 const AdminAuthPageRoute = ({ path, children }) => {
   const { isAuthed, user } = useAuth()
-  return (
-    <Route path={path}>
-      {isAuthed && user.admin ? <Page>{children}</Page> : <Redirect to="/login" />}
-    </Route>
-  )
+
+  if (!isAuthed) {
+    return <Redirect to="~/login" />
+  }
+
+  return <Route path={path}>{user.admin ? <Page>{children}</Page> : <Redirect to="/" />}</Route>
 }
 
-/**Saves the application on logout */
 const NavbarSaveOnLogout = ({ name, handleLogout }) => {
   const { forceSave } = useHackerApplication()
   const logout = async () => {
@@ -129,7 +136,7 @@ const ApplicationFormContainer = ({ part }) => {
       </Form>
     </>
   ) : (
-    <Redirect to="/login" />
+    <Redirect to="~/login" />
   )
 }
 
@@ -140,7 +147,7 @@ const JudgingViewContainer = ({ params }) => {
       <JudgingView id={params.id} />
     </Page>
   ) : (
-    <Redirect to="/login" />
+    <Redirect to="~/login" />
   )
 }
 
@@ -157,21 +164,50 @@ const ProjectViewContainer = ({ params }) => (
 
 const ApplicationDashboardRoutingContainer = () => {
   const { isAuthed } = useAuth()
-  return isAuthed ? <Application /> : <Redirect to="/login" />
+  return isAuthed ? <Application /> : <Redirect to="~/login" />
+}
+
+const NestedRoutes = props => {
+  const router = useRouter()
+  const [location] = useLocation()
+  const { activeHackathon, setActiveHackathon } = useHackathon()
+  const hackathonFromRoute = props.base.split('/')[2].toLowerCase()
+
+  useEffect(() => {
+    if (VALID_HACKATHONS.includes(hackathonFromRoute) && hackathonFromRoute !== activeHackathon) {
+      setActiveHackathon(hackathonFromRoute)
+    }
+  }, [props.base, activeHackathon, setActiveHackathon])
+
+  if (!location.startsWith(props.base)) return null
+
+  if (!VALID_HACKATHONS.includes(hackathonFromRoute)) {
+    return <Redirect to="/404" />
+  }
+
+  return (
+    <Router base={props.base} key={props.base} parent={router}>
+      {props.children}
+    </Router>
+  )
 }
 
 function App() {
-  // const [announcements, setAnnouncements] = useState([])
   const [announcementText, setAnnouncementText] = useState('')
+  const [location] = useLocation()
+
+  useEffect(() => {
+    if (location === '/') {
+      localStorage.removeItem('activeHackathon')
+      document.title = 'Hacker Portal'
+    }
+  }, [location])
 
   const notifyUser = async announcementId => {
-    // grab announcement from firebase to check if removed, if doesn't exist anymore don't send
     const announcement = await getAnnouncement(announcementId)
     if (!announcement) return
-    // only notify user if announcement is scheduled within last 5 secs
     const isRecent = new Date() - new Date(announcement.announcementTime) < 5000
     if (isRecent) {
-      // don't notify users on IOS devices because Notification API incompatible
       if (!IS_DEVICE_IOS && notifications.areEnabled()) {
         notifications.trigger('New Announcement', announcement.content)
       }
@@ -186,12 +222,10 @@ function App() {
       .collection('Announcements')
       .orderBy('timestamp', 'desc')
       .onSnapshot(querySnapshot => {
-        // firebase doc that triggered db change event
         const docChanges = querySnapshot.docChanges()
         const changedDoc = docChanges[0]
         const id = changedDoc?.doc.id
         const announcement = changedDoc?.doc.data()
-        // don't want to notify on 'remove' + 'modified' db events
         if (changedDoc?.type === 'added') {
           if (announcement.type === 'immediate') {
             notifyUser(id)
@@ -206,70 +240,96 @@ function App() {
   return (
     <HackathonProvider>
       <ThemeProvider>
+        <GlobalStyle />
         <AuthProvider>
-          <GlobalStyle />
-          <AnnouncementToast text={announcementText} />
           <Switch>
-            <PageRoute path="/">
-              <Home />
-            </PageRoute>
-            <PageRoute path="/charcuterie">
-              <Charcuterie />
-            </PageRoute>
-            <PageRoute path="/faq">
-              <Faq />
-            </PageRoute>
-            <PageRoute path="/schedule">
-              <Schedule />
-            </PageRoute>
-            <PageRoute path="/livestream">
-              <Livestream />
-            </PageRoute>
-            <PageRoute path="/sponsors">
-              <Sponsors />
-            </PageRoute>
-            {/* <PageRoute path="/getting-started">
-            <GettingStarted />
-          </PageRoute> */}
-            {/* <PageRoute path="/discord-bot">
-            <DiscordBot />
-          </PageRoute> */}
+            <Route path="/">
+              <Landing>
+                <Link href="/app/hackcamp">
+                  <A>Hackcamp</A>
+                </Link>
+                <br />
+                <Link href="/app/nwhacks">
+                  <A>nwHacks</A>
+                </Link>
+                <br />
+                <Link href="/app/cmd-f">
+                  <A>cmd-f</A>
+                </Link>
+              </Landing>
+            </Route>
             <NoAuthRoute path="/login">
-              <Navbar>
-                <Login />
-              </Navbar>
+              <Login />
             </NoAuthRoute>
-            <AuthPageRoute path="/judging">
-              <Judging />
-            </AuthPageRoute>
-            <AdminAuthPageRoute path="/judging/admin">
-              <JudgingAdmin />
-            </AdminAuthPageRoute>
-            {/* <AdminAuthPageRoute path="/area51">
-            <Area51 />
-          </AdminAuthPageRoute> */}
-            <Route path="/judging/view/:id" component={JudgingViewContainer} />
-            <Route path="/projects" component={GalleryContainer} />
-            <Route path="/projects/:id" component={ProjectViewContainer} />
-            <AuthPageRoute path="/submission">
-              <Submission />
-            </AuthPageRoute>
-            <HackerApplicationProvider>
-              <Switch>
-                <Route path="/application" component={ApplicationDashboardRoutingContainer} />
-                <ApplicationInProgressRoute path="/application/review" name handleLogout>
-                  <ApplicationReview />
-                </ApplicationInProgressRoute>
-                <ApplicationInProgressRoute path="/application/confirmation" handleLogout>
-                  <ApplicationConfirmation />
-                </ApplicationInProgressRoute>
-                <Route path="/application/:part" handleLogout>
-                  {params => <ApplicationFormContainer part={params.part} />}
-                </Route>
-              </Switch>
-            </HackerApplicationProvider>
-            <Route path="/:rest*">
+            <Route path="/app/:hackathon/:any*">
+              {params => (
+                <NestedRoutes base={`/app/${params.hackathon}`}>
+                  <Switch>
+                    <PageRoute path="/">
+                      <Home />
+                    </PageRoute>
+                    <PageRoute path="/charcuterie">
+                      <Charcuterie />
+                    </PageRoute>
+                    <PageRoute path="/faq">
+                      <Faq />
+                    </PageRoute>
+                    <PageRoute path="/schedule">
+                      <Schedule />
+                    </PageRoute>
+                    <PageRoute path="/livestream">
+                      <Livestream />
+                    </PageRoute>
+                    <PageRoute path="/sponsors">
+                      <Sponsors />
+                    </PageRoute>
+
+                    <AuthPageRoute path="/judging">
+                      <Judging />
+                    </AuthPageRoute>
+
+                    <AdminAuthPageRoute path="/judging/admin">
+                      <JudgingAdmin />
+                    </AdminAuthPageRoute>
+
+                    <Route path="/judging/view/:id" component={JudgingViewContainer} />
+                    <Route path="/projects" component={GalleryContainer} />
+                    <Route path="/projects/:id" component={ProjectViewContainer} />
+
+                    <AuthPageRoute path="/submission">
+                      <Submission />
+                    </AuthPageRoute>
+
+                    <HackerApplicationProvider>
+                      <Switch>
+                        <Route
+                          path="/application"
+                          component={ApplicationDashboardRoutingContainer}
+                        />
+                        <ApplicationInProgressRoute path="/application/review" name handleLogout>
+                          <ApplicationReview />
+                        </ApplicationInProgressRoute>
+                        <ApplicationInProgressRoute path="/application/confirmation" handleLogout>
+                          <ApplicationConfirmation />
+                        </ApplicationInProgressRoute>
+                        <Route path="/application/:part" handleLogout>
+                          {params => <ApplicationFormContainer part={params.part} />}
+                        </Route>
+                      </Switch>
+                    </HackerApplicationProvider>
+
+                    <Route>
+                      <Redirect to="~/404" />
+                    </Route>
+                  </Switch>
+                </NestedRoutes>
+              )}
+            </Route>
+            <Route path="/404">
               <NotFound />
+            </Route>
+            <Route>
+              <Redirect to="/404" />
             </Route>
           </Switch>
         </AuthProvider>
@@ -279,3 +339,18 @@ function App() {
 }
 
 export default App
+
+// <Hacker app provider routes></Hacker>
+
+// {/* <PageRoute path="/getting-started">
+// <GettingStarted />
+// </PageRoute> */}
+// {/* <PageRoute path="/discord-bot">
+// <DiscordBot />
+// </PageRoute> */}
+// {/* <AdminAuthPageRoute path="/area51">
+// <Area51 />
+// </AdminAuthPageRoute> */}
+// {
+//   /* <AnnouncementToast text={announcementText} /> */
+// }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,132 +1,46 @@
 import React, { useEffect, useState } from 'react'
-import { Link, Redirect, Route, Router, Switch, useLocation, useRouter } from 'wouter'
+import { Link, Redirect, Route, Switch, useLocation } from 'wouter'
 import AnnouncementToast from './components/AnnouncementToast'
-import Form from './components/ApplicationForm'
-import Navbar from './components/Navbar'
-import Page from './components/Page'
 import { A } from './components/Typography'
 import Landing from './containers/Landing'
 import {
-  Application,
   ApplicationConfirmation,
-  ApplicationForm,
   ApplicationReview,
   Charcuterie,
   Faq,
-  Gallery,
   Home,
   Judging,
   JudgingAdmin,
-  JudgingView,
   Livestream,
   Login,
   NotFound,
-  ProjectView,
   Schedule,
   Sponsors,
   Submission,
 } from './pages'
 import GlobalStyle from './theme/GlobalStyle'
 import ThemeProvider from './theme/ThemeProvider'
-import { AuthProvider, useAuth } from './utility/Auth'
-import {
-  APPLICATION_STATUS,
-  DB_COLLECTION,
-  DB_HACKATHON,
-  IS_DEVICE_IOS,
-  VALID_HACKATHONS,
-} from './utility/Constants'
-import HackathonProvider, { useHackathon } from './utility/HackathonProvider'
-import { HackerApplicationProvider, useHackerApplication } from './utility/HackerApplicationContext'
+import { AuthProvider } from './utility/Auth'
+import { DB_COLLECTION, DB_HACKATHON, IS_DEVICE_IOS } from './utility/Constants'
+import HackathonProvider from './utility/HackathonProvider'
+import { HackerApplicationProvider } from './utility/HackerApplicationContext'
 import {
   AdminAuthPageRoute,
   ApplicationInProgressRoute,
   AuthPageRoute,
+  NestedRoutes,
   NoAuthRoute,
   PageRoute,
 } from './utility/Routes'
+import {
+  ApplicationDashboardRoutingContainer,
+  ApplicationFormContainer,
+  GalleryContainer,
+  JudgingViewContainer,
+  ProjectViewContainer,
+} from './utility/RoutingContainers'
 import { db, getAnnouncement } from './utility/firebase'
 import notifications from './utility/notifications'
-
-const NavbarSaveOnLogout = ({ name, handleLogout }) => {
-  const { forceSave } = useHackerApplication()
-  const logout = async () => {
-    await forceSave()
-    handleLogout()
-  }
-
-  return <Navbar name={name} handleLogout={logout} />
-}
-
-const ApplicationFormContainer = ({ part }) => {
-  const { isAuthed, user, logout } = useAuth()
-  const { application } = useHackerApplication()
-
-  return isAuthed && application.status.applicationStatus === APPLICATION_STATUS.inProgress ? (
-    <>
-      <NavbarSaveOnLogout name={user.displayName} handleLogout={logout} />
-      <Form>
-        <ApplicationForm part={part} />
-      </Form>
-    </>
-  ) : (
-    <Redirect to="~/login" />
-  )
-}
-
-const JudgingViewContainer = ({ params }) => {
-  const { isAuthed } = useAuth()
-
-  return isAuthed ? (
-    <Page>
-      <JudgingView id={params.id} />
-    </Page>
-  ) : (
-    <Redirect to="~/login" />
-  )
-}
-
-const GalleryContainer = ({ params }) => (
-  <Page>
-    <Gallery />
-  </Page>
-)
-
-const ProjectViewContainer = ({ params }) => (
-  <Page>
-    <ProjectView pid={params.id} />
-  </Page>
-)
-
-const ApplicationDashboardRoutingContainer = () => {
-  const { isAuthed } = useAuth()
-  return isAuthed ? <Application /> : <Redirect to="~/login" />
-}
-
-const NestedRoutes = props => {
-  const router = useRouter()
-  const [location] = useLocation()
-  const { activeHackathon, setActiveHackathon } = useHackathon()
-  const hackathonFromURL = props.base.split('/')[2].toLowerCase()
-
-  useEffect(() => {
-    if (VALID_HACKATHONS.includes(hackathonFromURL) && hackathonFromURL !== activeHackathon) {
-      setActiveHackathon(hackathonFromURL)
-    }
-  }, [props.base, activeHackathon, setActiveHackathon])
-
-  if (!location.startsWith(props.base)) return null
-
-  if (!VALID_HACKATHONS.includes(hackathonFromURL)) {
-    return <Redirect to="~/404" />
-  }
-
-  return (
-    <Router base={props.base} key={props.base} parent={router}>
-      {props.children}
-    </Router>
-  )
-}
 
 function App() {
   const [announcementText, setAnnouncementText] = useState('')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import { Redirect, Route, Switch, useLocation, useRouter, Router, Link } from 'wouter'
+import { Link, Redirect, Route, Router, Switch, useLocation, useRouter } from 'wouter'
+import AnnouncementToast from './components/AnnouncementToast'
 import Form from './components/ApplicationForm'
 import Navbar from './components/Navbar'
 import Page from './components/Page'
+import { A } from './components/Typography'
+import Landing from './containers/Landing'
 import {
   Application,
   ApplicationConfirmation,
@@ -12,10 +15,10 @@ import {
   Faq,
   Gallery,
   Home,
-  Livestream,
   Judging,
   JudgingAdmin,
   JudgingView,
+  Livestream,
   Login,
   NotFound,
   ProjectView,
@@ -25,7 +28,7 @@ import {
 } from './pages'
 import GlobalStyle from './theme/GlobalStyle'
 import ThemeProvider from './theme/ThemeProvider'
-import { AuthProvider, getRedirectUrl, useAuth } from './utility/Auth'
+import { AuthProvider, useAuth } from './utility/Auth'
 import {
   APPLICATION_STATUS,
   DB_COLLECTION,
@@ -33,87 +36,17 @@ import {
   IS_DEVICE_IOS,
   VALID_HACKATHONS,
 } from './utility/Constants'
-import { HackerApplicationProvider, useHackerApplication } from './utility/HackerApplicationContext'
-import { db, getAnnouncement, getLivesiteDoc } from './utility/firebase'
-import notifications from './utility/notifications'
-import AnnouncementToast from './components/AnnouncementToast'
 import HackathonProvider, { useHackathon } from './utility/HackathonProvider'
-import Landing from './containers/Landing'
-import { A } from './components/Typography'
-
-const PageRoute = ({ path, children }) => {
-  const [livesiteDoc, setLivesiteDoc] = useState(null)
-
-  useEffect(() => {
-    const unsubscribe = getLivesiteDoc(setLivesiteDoc)
-    return unsubscribe
-  }, [])
-
-  return (
-    <Route path={path}>
-      {livesiteDoc?.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
-    </Route>
-  )
-}
-
-const AuthPageRoute = ({ path, children }) => {
-  const { isAuthed, user } = useAuth()
-
-  if (!isAuthed) {
-    return (
-      <Route path={path}>
-        <Redirect to="~/login" />
-      </Route>
-    )
-  }
-  return (
-    <Route path={path}>
-      {user?.status === APPLICATION_STATUS.accepted ? (
-        <Page>{children}</Page>
-      ) : (
-        <Redirect to="/application/closed" />
-      )}
-    </Route>
-  )
-}
-
-const ApplicationInProgressRoute = ({ name, handleLogout, path, children }) => {
-  const { isAuthed, user, logout } = useAuth()
-
-  return isAuthed ? (
-    <Route path={path}>
-      <Navbar
-        name={name ? user.displayName : undefined}
-        handleLogout={handleLogout ? logout : undefined}
-      >
-        {children}
-      </Navbar>
-    </Route>
-  ) : (
-    <Redirect to="~/login" />
-  )
-}
-
-const NoAuthRoute = ({ path, children }) => {
-  const { isAuthed, user } = useAuth()
-  const { activeHackathon } = useHackathon()
-
-  return (
-    <Route path={path}>
-      {!isAuthed ? children : <Redirect to={getRedirectUrl(user.redirect, activeHackathon)} />}
-    </Route>
-  )
-}
-
-const AdminAuthPageRoute = ({ path, children }) => {
-  const { isAuthed, user } = useAuth()
-
-  if (!isAuthed) {
-    return <Redirect to="~/login" />
-  }
-
-  return <Route path={path}>{user.admin ? <Page>{children}</Page> : <Redirect to="~/404" />}</Route>
-}
+import { HackerApplicationProvider, useHackerApplication } from './utility/HackerApplicationContext'
+import {
+  AdminAuthPageRoute,
+  ApplicationInProgressRoute,
+  AuthPageRoute,
+  NoAuthRoute,
+  PageRoute,
+} from './utility/Routes'
+import { db, getAnnouncement } from './utility/firebase'
+import notifications from './utility/notifications'
 
 const NavbarSaveOnLogout = ({ name, handleLogout }) => {
   const { forceSave } = useHackerApplication()

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import {
 // import Area51 from './pages/Area51'
 import GlobalStyle from './theme/GlobalStyle'
 import ThemeProvider from './theme/ThemeProvider'
+import HackathonProvider from './utility/HackathonProvider'
 import { AuthProvider, getRedirectUrl, useAuth } from './utility/Auth'
 import { APPLICATION_STATUS, DB_COLLECTION, DB_HACKATHON, IS_DEVICE_IOS } from './utility/Constants'
 import { HackerApplicationProvider, useHackerApplication } from './utility/HackerApplicationContext'
@@ -203,75 +204,77 @@ function App() {
   }, [])
 
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <GlobalStyle />
-        <AnnouncementToast text={announcementText} />
-        <Switch>
-          <PageRoute path="/">
-            <Home />
-          </PageRoute>
-          <PageRoute path="/charcuterie">
-            <Charcuterie />
-          </PageRoute>
-          <PageRoute path="/faq">
-            <Faq />
-          </PageRoute>
-          <PageRoute path="/schedule">
-            <Schedule />
-          </PageRoute>
-          <PageRoute path="/livestream">
-            <Livestream />
-          </PageRoute>
-          <PageRoute path="/sponsors">
-            <Sponsors />
-          </PageRoute>
-          {/* <PageRoute path="/getting-started">
+    <HackathonProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <GlobalStyle />
+          <AnnouncementToast text={announcementText} />
+          <Switch>
+            <PageRoute path="/">
+              <Home />
+            </PageRoute>
+            <PageRoute path="/charcuterie">
+              <Charcuterie />
+            </PageRoute>
+            <PageRoute path="/faq">
+              <Faq />
+            </PageRoute>
+            <PageRoute path="/schedule">
+              <Schedule />
+            </PageRoute>
+            <PageRoute path="/livestream">
+              <Livestream />
+            </PageRoute>
+            <PageRoute path="/sponsors">
+              <Sponsors />
+            </PageRoute>
+            {/* <PageRoute path="/getting-started">
             <GettingStarted />
           </PageRoute> */}
-          {/* <PageRoute path="/discord-bot">
+            {/* <PageRoute path="/discord-bot">
             <DiscordBot />
           </PageRoute> */}
-          <NoAuthRoute path="/login">
-            <Navbar>
-              <Login />
-            </Navbar>
-          </NoAuthRoute>
-          <AuthPageRoute path="/judging">
-            <Judging />
-          </AuthPageRoute>
-          <AdminAuthPageRoute path="/judging/admin">
-            <JudgingAdmin />
-          </AdminAuthPageRoute>
-          {/* <AdminAuthPageRoute path="/area51">
+            <NoAuthRoute path="/login">
+              <Navbar>
+                <Login />
+              </Navbar>
+            </NoAuthRoute>
+            <AuthPageRoute path="/judging">
+              <Judging />
+            </AuthPageRoute>
+            <AdminAuthPageRoute path="/judging/admin">
+              <JudgingAdmin />
+            </AdminAuthPageRoute>
+            {/* <AdminAuthPageRoute path="/area51">
             <Area51 />
           </AdminAuthPageRoute> */}
-          <Route path="/judging/view/:id" component={JudgingViewContainer} />
-          <Route path="/projects" component={GalleryContainer} />
-          <Route path="/projects/:id" component={ProjectViewContainer} />
-          <AuthPageRoute path="/submission">
-            <Submission />
-          </AuthPageRoute>
-          <HackerApplicationProvider>
-            <Switch>
-              <Route path="/application" component={ApplicationDashboardRoutingContainer} />
-              <ApplicationInProgressRoute path="/application/review" name handleLogout>
-                <ApplicationReview />
-              </ApplicationInProgressRoute>
-              <ApplicationInProgressRoute path="/application/confirmation" handleLogout>
-                <ApplicationConfirmation />
-              </ApplicationInProgressRoute>
-              <Route path="/application/:part" handleLogout>
-                {params => <ApplicationFormContainer part={params.part} />}
-              </Route>
-            </Switch>
-          </HackerApplicationProvider>
-          <Route path="/:rest*">
-            <NotFound />
-          </Route>
-        </Switch>
-      </AuthProvider>
-    </ThemeProvider>
+            <Route path="/judging/view/:id" component={JudgingViewContainer} />
+            <Route path="/projects" component={GalleryContainer} />
+            <Route path="/projects/:id" component={ProjectViewContainer} />
+            <AuthPageRoute path="/submission">
+              <Submission />
+            </AuthPageRoute>
+            <HackerApplicationProvider>
+              <Switch>
+                <Route path="/application" component={ApplicationDashboardRoutingContainer} />
+                <ApplicationInProgressRoute path="/application/review" name handleLogout>
+                  <ApplicationReview />
+                </ApplicationInProgressRoute>
+                <ApplicationInProgressRoute path="/application/confirmation" handleLogout>
+                  <ApplicationConfirmation />
+                </ApplicationInProgressRoute>
+                <Route path="/application/:part" handleLogout>
+                  {params => <ApplicationFormContainer part={params.part} />}
+                </Route>
+              </Switch>
+            </HackerApplicationProvider>
+            <Route path="/:rest*">
+              <NotFound />
+            </Route>
+          </Switch>
+        </AuthProvider>
+      </ThemeProvider>
+    </HackathonProvider>
   )
 }
 

--- a/src/components/ApplicationDashboard.jsx
+++ b/src/components/ApplicationDashboard.jsx
@@ -473,11 +473,11 @@ const Dashboard = ({
           {isApplicationOpen && (
             <EditAppButton
               height="short"
-              onClick={
-                isApplicationOpen &&
-                hackerStatus === APPLICATION_STATUS.inProgress &&
-                (() => editApplication())
-              }
+              onClick={() => {
+                if (isApplicationOpen && hackerStatus === APPLICATION_STATUS.inProgress) {
+                  editApplication()
+                }
+              }}
               disabled={!(isApplicationOpen && hackerStatus === APPLICATION_STATUS.inProgress)}
             >
               Complete Your Registration

--- a/src/components/Input/ToggleSwitch.jsx
+++ b/src/components/Input/ToggleSwitch.jsx
@@ -71,7 +71,7 @@ const Input = styled.input`
   }
 `
 
-const ToggleSwitch = ({ checked, disabled, disabledTooltip, onChange }) => {
+const ToggleSwitch = ({ checked = false, disabled, disabledTooltip, onChange }) => {
   return (
     <ToggleSwitchContainer>
       <label>

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { withTheme } from 'styled-components'
 import { css } from '@emotion/core'
 import MoonLoader from 'react-spinners/MoonLoader'
 
@@ -13,6 +12,6 @@ const override = css`
   z-index: 1031;
 `
 
-export default withTheme(({ loading, theme, size = 80 }) => (
-  <MoonLoader css={override} color={theme.colors.primary} size={size} loading={loading} />
-))
+export default ({ loading, color = '#78FF96', size = 80 }) => (
+  <MoonLoader css={override} color={color} size={size} loading={loading} />
+)

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -4,6 +4,7 @@ import cmdfIcon from '../assets/cmdf_logo.png'
 import nwplus_logo from '../assets/nwplus_icon.svg'
 import { Button } from './Input'
 import { P } from './Typography'
+import { useHackathon } from '../utility/HackathonProvider'
 
 const NavContainer = styled.div`
   direction: rtl;
@@ -54,7 +55,9 @@ const Wrapper = styled.div`
   padding-top: 1rem;
 `
 
-const NavBar = ({ name, handleLogout, children, theme }) => {
+const NavBar = ({ name, handleLogout, children }) => {
+  const { activeHackathon } = useHackathon()
+
   return (
     <Wrapper>
       <NavContainer>
@@ -71,16 +74,16 @@ const NavBar = ({ name, handleLogout, children, theme }) => {
             <Greeting>Hi, {name}</Greeting>
           </>
         )}
-        {theme.name === 'nwHacks' && (
+        {activeHackathon === 'nwhacks' && (
           <LogoContainer>
             {/* <SponsorIcon src={poweredBy} alt="powered by Livepeer" /> */}
-            <Icon src={nwplus_logo} alt={theme.name} />
+            <Icon src={nwplus_logo} alt={activeHackathon} />
           </LogoContainer>
         )}
-        {theme.name === 'cmdf' && (
+        {activeHackathon === 'cmd-f' && (
           <LogoContainer>
             {/* <SponsorIcon src={poweredBy} alt="powered by Livepeer" /> */}
-            <Icon src={cmdfIcon} alt={theme.name} />
+            <Icon src={cmdfIcon} alt={activeHackathon} />
           </LogoContainer>
         )}
       </NavContainer>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, { withTheme } from 'styled-components'
 import cmdfIcon from '../assets/cmdf_logo.png'
-import nwplus_logo from '../assets/nwplus_icon.svg'
+import nwhacks_logo from '../assets/nwhacks_logo.svg'
 import { Button } from './Input'
 import { P } from './Typography'
 import { useHackathon } from '../utility/HackathonProvider'
@@ -77,7 +77,7 @@ const NavBar = ({ name, handleLogout, children }) => {
         {activeHackathon === 'nwhacks' && (
           <LogoContainer>
             {/* <SponsorIcon src={poweredBy} alt="powered by Livepeer" /> */}
-            <Icon src={nwplus_logo} alt={activeHackathon} />
+            <Icon src={nwhacks_logo} alt={activeHackathon} />
           </LogoContainer>
         )}
         {activeHackathon === 'cmd-f' && (

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled, { withTheme } from 'styled-components'
 import cmdfIcon from '../assets/cmdf_logo.png'
 import nwhacks_logo from '../assets/nwhacks_logo.svg'
+import hc_logo from '../assets/hc_logo.svg'
 import { Button } from './Input'
 import { P } from './Typography'
 import { useHackathon } from '../utility/HackathonProvider'
@@ -74,16 +75,20 @@ const NavBar = ({ name, handleLogout, children }) => {
             <Greeting>Hi, {name}</Greeting>
           </>
         )}
+        {activeHackathon === 'hackcamp' && (
+          <LogoContainer>
+            <Icon src={hc_logo} alt={'HackCamp'} />
+          </LogoContainer>
+        )}
         {activeHackathon === 'nwhacks' && (
           <LogoContainer>
             {/* <SponsorIcon src={poweredBy} alt="powered by Livepeer" /> */}
-            <Icon src={nwhacks_logo} alt={activeHackathon} />
+            <Icon src={nwhacks_logo} alt={'nwHacks'} />
           </LogoContainer>
         )}
         {activeHackathon === 'cmd-f' && (
           <LogoContainer>
-            {/* <SponsorIcon src={poweredBy} alt="powered by Livepeer" /> */}
-            <Icon src={cmdfIcon} alt={activeHackathon} />
+            <Icon src={cmdfIcon} alt={'cmd-f'} />
           </LogoContainer>
         )}
       </NavContainer>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -32,12 +32,12 @@ const chooseLogo = hackathon => {
   switch (hackathon) {
     case 'hackCamp':
       return hc_logo
-    case 'cmdf':
+    case 'cmd-f':
       return cmdf_logo
     case 'nwHacks':
-      return nwplus_logo
-    default:
       return logo
+    default:
+      return nwplus_logo
   }
 }
 
@@ -52,7 +52,7 @@ const Logo = styled.img.attrs(p => ({
     p.theme.name === 'hackCamp' &&
     `
       width: 120px;
-      margin: 30px 0 0px 2rem;
+      margin: 30px 0 0px 2rem; 
     `}
 `
 
@@ -198,7 +198,7 @@ const Sidebar = ({
   const links = {
     // General
     general: [
-      { location: '/', text: 'My Ticket' },
+      { location: '', text: 'My Ticket' },
       { location: '/schedule', text: 'Schedule' },
       { location: '/livestream', text: 'Livestream' },
       { location: '/sponsors', text: 'Sponsors' },
@@ -296,14 +296,14 @@ const Sidebar = ({
               return (
                 t[1].length > 0 &&
                 t[0] !== 'useful_links' && (
-                  <>
+                  <React.Fragment key={k}>
                     <CategoryHeader>{t[0].replace('_', ' ')}</CategoryHeader>
                     {t[1].map((v, i) => (
-                      <Link key={i} href={v.location} onClick={hideSidebarCallback}>
+                      <Link key={v.location} href={v.location} onClick={hideSidebarCallback}>
                         <StyledA selected={location === v.location}>{v.text}</StyledA>
                       </Link>
                     ))}
-                  </>
+                  </React.Fragment>
                 )
               )
             })}
@@ -341,6 +341,14 @@ const Sidebar = ({
           Log In
         </StyledButton>
       )}
+      <StyledButton
+        as={Link}
+        href="~/"
+        color="secondary"
+        style={{ textDecoration: 'none', color: 'white' }}
+      >
+        Home
+      </StyledButton>
       <SponsorContainer>
         {sponsors &&
           sponsors.map(sponsor => <SponsorLogo key={sponsor.name} src={sponsor.imgURL} />)}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { Link, useLocation } from 'wouter'
 import cmdf_logo from '../assets/cmdf_logo.png'
 import hc_logo from '../assets/hc_logo.svg'
-import logo from '../assets/logo.svg'
+import nwhacks_logo from '../assets/nwhacks_logo.svg'
 import nwplus_logo from '../assets/nwplus_icon.svg'
 import { useAuth } from '../utility/Auth'
 import { getSponsors } from '../utility/firebase'
@@ -35,7 +35,7 @@ const chooseLogo = hackathon => {
     case 'cmd-f':
       return cmdf_logo
     case 'nwhacks':
-      return logo
+      return nwhacks_logo
     default:
       return nwplus_logo
   }
@@ -45,14 +45,13 @@ const Logo = styled.img.attrs(p => ({
   src: chooseLogo(p.theme.name),
 }))`
   height: 7em;
-  margin: auto;
+  margin: 2em auto;
   display: block;
 
   ${p =>
     p.theme.name === 'hackcamp' &&
     `
-      width: 120px;
-      margin: 30px 0 0px 2rem; 
+      width: 150px;
     `}
 `
 
@@ -169,7 +168,6 @@ const CategoryHeader = styled.h4`
 `
 
 const LogoContainer = styled.div`
-  margin-top: 2em;
   display: flex;
   align-items: flex-end;
 `

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -30,11 +30,11 @@ const SidebarContainer = styled.div`
 
 const chooseLogo = hackathon => {
   switch (hackathon) {
-    case 'hackCamp':
+    case 'hackcamp':
       return hc_logo
     case 'cmd-f':
       return cmdf_logo
-    case 'nwHacks':
+    case 'nwhacks':
       return logo
     default:
       return nwplus_logo
@@ -49,7 +49,7 @@ const Logo = styled.img.attrs(p => ({
   display: block;
 
   ${p =>
-    p.theme.name === 'hackCamp' &&
+    p.theme.name === 'hackcamp' &&
     `
       width: 120px;
       margin: 30px 0 0px 2rem; 
@@ -211,11 +211,7 @@ const Sidebar = ({
       // (conditional) Judging (Admin)
     ],
     // Information
-    information: [
-      // { location: '/getting-started', text: 'Getting Started' },
-      // { location: '/discord-bot', text: 'Discord Bot' },
-      { location: '/faq', text: 'FAQ' },
-    ],
+    information: [{ location: '/faq', text: 'FAQ' }],
     useful_links: [
       {
         location:

--- a/src/containers/Application/Dashboard.jsx
+++ b/src/containers/Application/Dashboard.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useLocation } from 'wouter'
 import Dashboard from '../../components/ApplicationDashboard'
-import Spinner from '../../components/Loading'
 import Page from '../../components/Page'
 import { useAuth } from '../../utility/Auth'
 import { uploadWaiverToStorage, useHackerApplication } from '../../utility/HackerApplicationContext'
@@ -179,9 +178,7 @@ const ApplicationDashboardContainer = () => {
     return unsubscribe
   }, [setLivesiteDoc])
 
-  return isLoadingAppStatus ? (
-    <Spinner />
-  ) : (
+  return isLoadingAppStatus ? null : (
     <Page hackerStatus={hackerStatus}>
       <Dashboard
         editApplication={() => setLocation('/application/part-0')}

--- a/src/containers/Application/Part0.jsx
+++ b/src/containers/Application/Part0.jsx
@@ -32,7 +32,7 @@ const Part0 = () => {
       <NavigationButtons
         secondButtonText="Next"
         secondButtonOnClick={() => handleNavigation('/application/part-1')}
-        autosaveTime={application.submission.lastUpdated.toDate().toString()}
+        autosaveTime={application.submission.lastUpdated?.toDate().toString() || ''}
         loading={loading}
       />
     </>

--- a/src/containers/Application/Part1.jsx
+++ b/src/containers/Application/Part1.jsx
@@ -125,7 +125,7 @@ const Part1 = () => {
         firstButtonOnClick={() => handleNavigation('/application/part-0')}
         secondButtonText="Next"
         secondButtonOnClick={() => handleNavigation('/application/part-2')}
-        autosaveTime={application.submission.lastUpdated.toDate().toString()}
+        autosaveTime={application.submission.lastUpdated?.toDate().toString() || ''}
         loading={loading}
       />
     </>

--- a/src/containers/Application/Part2.jsx
+++ b/src/containers/Application/Part2.jsx
@@ -113,7 +113,7 @@ const Part2 = () => {
         firstButtonOnClick={() => handleNavigation('/application/part-1')}
         secondButtonText="Next"
         secondButtonOnClick={() => handleNavigation('/application/part-3')}
-        autosaveTime={application.submission.lastUpdated.toDate().toString()}
+        autosaveTime={application.submission.lastUpdated?.toDate().toString() || ''}
         loading={loading}
       />
     </>

--- a/src/containers/Application/Part3.jsx
+++ b/src/containers/Application/Part3.jsx
@@ -60,7 +60,7 @@ const Part3 = () => {
         firstButtonOnClick={() => handleNavigation('/application/part-2')}
         secondButtonText="Review Your Submission"
         secondButtonOnClick={() => handleNavigation('/application/review')}
-        autosaveTime={application.submission.lastUpdated.toDate().toString()}
+        autosaveTime={application.submission.lastUpdated?.toDate().toString() || ''}
         loading={loading}
       />
     </>

--- a/src/containers/GalleryPage.jsx
+++ b/src/containers/GalleryPage.jsx
@@ -89,7 +89,7 @@ export function GalleryPage({ projects, startingPageIndex = 0 }) {
                   imgUrl={getYoutubeThumbnail(project.links.youtube)}
                   buttonLabel="See more"
                   buttonDisabled={false}
-                  href={'projects/' + project.uid}
+                  href={'/projects/' + project.uid}
                 />
               </CardContainerWrap>
             ))}

--- a/src/containers/Landing/index.jsx
+++ b/src/containers/Landing/index.jsx
@@ -55,7 +55,7 @@ const StyledLogoLockup = styled.img`
       width: 120px;
   `}
   ${p =>
-    p.theme.name === 'cmdf' &&
+    p.theme.name === 'cmd-f' &&
     `
       top: 30%;
     `}
@@ -125,7 +125,7 @@ const Landing = ({ heading, description, showFooter, hackathon, children, backgr
           {showFooter && <Footer />}
         </LandingContainer>
       )
-    case 'cmdf':
+    case 'cmd-f':
       return (
         <LandingContainer showFooter={showFooter}>
           <BackgroundContainer src={cmdfLoginBackground} />
@@ -138,8 +138,8 @@ const Landing = ({ heading, description, showFooter, hackathon, children, backgr
           {showFooter && <Footer />}
         </LandingContainer>
       )
+    case 'nwhacks':
     default:
-    case 'nwHacks':
       return (
         <LandingContainer showFooter={showFooter}>
           <BackgroundContainer src={nwHacksLoginBackground} />

--- a/src/containers/Landing/index.jsx
+++ b/src/containers/Landing/index.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import cmdf_logo from '../../assets/cmdf_logo.png'
 import hc_logo from '../../assets/hc_logo.svg'
+import nwhacks_logo from '../../assets/nwhacks_logo.svg'
 import nwplus_logo from '../../assets/nwplus_icon.svg'
 import Banner from '../../components/Banner'
 import { H1, P } from '../../components/Typography'
@@ -106,50 +107,28 @@ const BackgroundContainer = styled.img`
   }
 `
 
-// TODO: add sponsors if footer is shown
-const Landing = ({ heading, description, showFooter, hackathon, children, background }) => {
-  switch (hackathon) {
-    case 'hackcamp':
-      return (
-        <LandingContainer showFooter={showFooter}>
-          <StyledLogoLockup src={hc_logo} />
-          <StyledBanner>
-            <H1 size="1.5em">{heading}</H1>
-            <P>{description}</P>
-            {children}
-          </StyledBanner>
-          {showFooter && <Footer />}
-        </LandingContainer>
-      )
-    case 'cmd-f':
-      return (
-        <LandingContainer showFooter={showFooter}>
-          <BackgroundContainer src={cmdfLoginBackground} />
-          <StyledLogoLockup src={cmdf_logo} />
-          <StyledBanner>
-            <H1 size="1.5em">{heading}</H1>
-            <P>{description}</P>
-            {children}
-          </StyledBanner>
-          {showFooter && <Footer />}
-        </LandingContainer>
-      )
-    case 'nwhacks':
-    default:
-      return (
-        <LandingContainer showFooter={showFooter}>
-          <BackgroundContainer src={nwHacksLoginBackground} />
-
-          <StyledLogoLockup src={nwplus_logo} />
-          <StyledBanner>
-            <H1 size="1.5em">{heading}</H1>
-            <P>{description}</P>
-            {children}
-          </StyledBanner>
-          {showFooter && <Footer />}
-        </LandingContainer>
-      )
+const Landing = ({ heading, description, showFooter, hackathon, children }) => {
+  const options = {
+    'hackcamp': { logo: hc_logo, background: null },
+    'cmd-f': { logo: cmdf_logo, background: cmdfLoginBackground },
+    'nwhacks': { logo: nwhacks_logo, background: nwHacksLoginBackground },
+    'default': { logo: nwplus_logo, background: nwHacksLoginBackground },
   }
+
+  const { logo, background } = options[hackathon] || options.default
+
+  return (
+    <LandingContainer showFooter={showFooter}>
+      {background && <BackgroundContainer src={background} />}
+      <StyledLogoLockup src={logo} />
+      <StyledBanner>
+        <H1 size="1.5em">{heading}</H1>
+        <P>{description}</P>
+        {children}
+      </StyledBanner>
+      {showFooter && <Footer />}
+    </LandingContainer>
+  )
 }
 
 export default Landing

--- a/src/containers/Landing/index.jsx
+++ b/src/containers/Landing/index.jsx
@@ -54,11 +54,7 @@ const StyledLogoLockup = styled.img`
       top: 7em;
       width: 120px;
   `}
-  ${p =>
-    p.theme.name === 'cmd-f' &&
-    `
-      top: 30%;
-    `}
+
   ${p => p.theme.mediaQueries.tabletLarge} {
     top: 20%;
     width: 15%;
@@ -113,7 +109,7 @@ const BackgroundContainer = styled.img`
 // TODO: add sponsors if footer is shown
 const Landing = ({ heading, description, showFooter, hackathon, children, background }) => {
   switch (hackathon) {
-    case 'hackCamp':
+    case 'hackcamp':
       return (
         <LandingContainer showFooter={showFooter}>
           <StyledLogoLockup src={hc_logo} />

--- a/src/containers/NotificationToggle.jsx
+++ b/src/containers/NotificationToggle.jsx
@@ -28,11 +28,7 @@ const StyledH2 = styled(H2)`
 `
 
 const NotificationToggle = () => {
-  const [toggled, setToggled] = useState(false)
-
-  useEffect(() => {
-    setToggled(notifications.areEnabled())
-  }, [setToggled])
+  const [toggled, setToggled] = useState(() => notifications.areEnabled() || false)
 
   const handleToggle = e => {
     // if user's first time on site, request notification permissions from browser

--- a/src/pages/Application/Closed.jsx
+++ b/src/pages/Application/Closed.jsx
@@ -3,10 +3,10 @@ import Landing from '../../containers/Landing'
 import { A } from '../../components/Typography'
 import { SOCIAL_LINKS } from '../../utility/Constants'
 import { copyText } from '../../utility/Constants'
-import { ThemeContext } from 'styled-components'
+import { useHackathon } from '../../utility/HackathonProvider'
 
 const Closed = () => {
-  const theme = useContext(ThemeContext)
+  const { activeHackathon } = useHackathon()
 
   return (
     <Landing
@@ -23,7 +23,7 @@ const Closed = () => {
         </>
       }
       showFooter
-      hackathon={theme.name}
+      hackathon={activeHackathon}
     />
   )
 }

--- a/src/pages/Application/Confirmation.jsx
+++ b/src/pages/Application/Confirmation.jsx
@@ -3,14 +3,16 @@ import { useLocation } from 'wouter'
 import { Button } from '../../components/Input'
 import Landing from '../../containers/Landing'
 import { ButtonContainer } from '../Login'
+import { useHackathon } from '../../utility/HackathonProvider'
 
 const Confirmation = () => {
   const [, setLocation] = useLocation()
+  const { activeHackathon } = useHackathon()
   return (
     <Landing
       heading="Thanks for Applying!"
       description="Stay tuned as we assess your application. Expect to hear from us soon."
-      hackathon="cmdf"
+      hackathon={activeHackathon}
       showFooter
     >
       <ButtonContainer>

--- a/src/pages/Application/Form.jsx
+++ b/src/pages/Application/Form.jsx
@@ -16,7 +16,7 @@ const Form = ({ part }) => {
     case 'part-3':
       return <Part3 />
     default:
-      return <Redirect to="/login" />
+      return <Redirect to="~/login" />
   }
 }
 

--- a/src/pages/Charcuterie.jsx
+++ b/src/pages/Charcuterie.jsx
@@ -12,6 +12,8 @@ import ResumeUploadBtn from '../components/ResumeUploadBtn'
 import styled from 'styled-components'
 import NavigationButtons from '../components/NavigationButtons'
 import Loading from '../components/Loading'
+import { useHackathon } from '../utility/HackathonProvider'
+import { useLocation } from 'wouter'
 
 const CustomStyledDropdown = styled(Dropdown)`
   .react-select__control {
@@ -43,19 +45,19 @@ const options = [
   { value: '6', label: 'Van' },
 ]
 
-const toggleTheme = () => {
-  const oldTheme = window.localStorage.getItem('localTheme')
-  if (oldTheme === 'nwTheme') {
-    window.localStorage.setItem('localTheme', 'cmdfTheme')
-  } else if (oldTheme === 'cmdfTheme') {
-    window.localStorage.setItem('localTheme', 'hackcampTheme')
+const toggleTheme = (navigate, activeHackathon) => {
+  if (activeHackathon === 'hackcamp') {
+    navigate('~/app/nwhacks/charcuterie')
+  } else if (activeHackathon === 'nwhacks') {
+    navigate('~/app/cmd-f/charcuterie')
   } else {
-    window.localStorage.setItem('localTheme', 'nwTheme')
+    navigate('~/app/hackcamp/charcuterie')
   }
-  window.location.reload()
 }
 
 const Charcuterie = () => {
+  const { activeHackathon, setActiveHackathon } = useHackathon()
+  const [_, navigate] = useLocation()
   const [states, setStates] = useState({
     checkbox: false,
     radio: 'selected',
@@ -75,7 +77,11 @@ const Charcuterie = () => {
   `
   return (
     <>
-      <Button color="secondary" width="flex" href={`javascript:(${toggleTheme})()`}>
+      <Button
+        color="secondary"
+        width="flex"
+        onClick={() => toggleTheme(navigate, activeHackathon, setActiveHackathon)}
+      >
         Toggle Theme
       </Button>
       <Button color="secondary" width="flex" onClick={() => setIsLoading(!isLoading)}>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -11,6 +11,7 @@ import { APPLICATION_STATUS } from '../utility/Constants'
 import { P } from '../components/Typography'
 import backgroundImage from '../assets/cmdf_homebg.svg'
 import mobileBackgroundImage from '../assets/cmdf_mobilebg.svg'
+import { useHackathon } from '../utility/HackathonProvider'
 
 //My Ticket
 const HomeContainer = styled.div`
@@ -57,13 +58,14 @@ const StyledP = styled(P)`
 
 export default withTheme(({ announcements, theme }) => {
   const { user, isAuthed } = useAuth()
+  const { activeHackathon } = useHackathon()
 
   return (
     <>
       <HomeContainerBackground />
       <HomeContainer>
-        {theme.name === 'cmdf'}
-        {/* {theme.name === 'hackCamp' && <Hackcamp2023BG />} */}
+        {activeHackathon === 'cmd-f'}
+        {/* {activeHackathon === 'hackcamp' && <Hackcamp2023BG />} */}
         <HackerCountdown />
         {/* 
       <CommonLinks />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -34,7 +34,7 @@ const HomeContainerBackground = styled.div`
   display: flex;
   flex-direction: column;
   background-image: url(${backgroundImage});
-  background-size: 120%;
+  background-size: cover;
   background-position: right bottom;
   ${p => p.theme.mediaQueries.mobile} {
     background-image: url(${mobileBackgroundImage});

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -11,6 +11,7 @@ import { useLocation } from 'wouter'
 import Toast from '../components/Toast'
 import { A } from '../components/Typography'
 import { copyText } from '../utility/Constants'
+import { useHackathon } from '../utility/HackathonProvider'
 
 const ErrorMessage = ({ message }) => (
   <>
@@ -65,22 +66,23 @@ const Login = () => {
   const { setUser } = useAuth()
   const [, setLocation] = useLocation()
   const [error, setError] = useState(null)
+  const { activeHackathon } = useHackathon()
 
   const signInWithGoogle = async () => {
-    const error = await googleSignIn(setUser, setLocation)
+    const error = await googleSignIn(setUser, setLocation, activeHackathon)
     setError(error)
   }
 
   const signInWithGithub = async () => {
-    const error = await githubSignIn(setUser, setLocation)
+    const error = await githubSignIn(setUser, setLocation, activeHackathon)
     setError(error)
   }
 
   return (
     <>
       <Landing
-        heading={`Welcome to ${copyText.hackathonName}!`}
-        hackathon={theme.name}
+        heading={`Welcome to nwPlus!`}
+        hackathon={`nwPlus`}
         background={theme.colors.login.background}
       >
         <ButtonContainer>
@@ -105,7 +107,6 @@ const Login = () => {
             Sign in with GitHub
           </StyledButton>
         </ButtonContainer>
-        {DB_HACKATHON === 'LHD2021' && <A href="/">Return to Portal</A>}
       </Landing>
       <Toast>{error ? handleAuthError(error.code, error.message) : null}</Toast>
     </>

--- a/src/theme/ThemeProvider.jsx
+++ b/src/theme/ThemeProvider.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { ThemeProvider as TP } from 'styled-components'
+import { useHackathon } from '../utility/HackathonProvider'
 
 const SCREEN_BREAKPOINTS = {
   xs: 576,
@@ -40,7 +41,7 @@ const base = {
   },
 }
 
-const nwTheme = {
+const nwHacksTheme = {
   ...base,
   name: 'nwHacks',
   colors: {
@@ -179,7 +180,7 @@ const hackcampTheme = {
 
 const cmdfTheme = {
   ...base,
-  name: 'cmdf',
+  name: 'cmd-f',
   colors: {
     background: '#5968A6',
     card: '#323858', // BG Accent
@@ -257,15 +258,13 @@ const cmdfTheme = {
   },
 }
 
-const THEMES = { nwTheme, hackcampTheme, cmdfTheme }
-let selectedTheme = cmdfTheme
+const THEMES = { 'hackcamp': hackcampTheme, 'nwhacks': nwHacksTheme, 'cmd-f': cmdfTheme }
 
-if (import.meta.env.NODE_ENV !== 'production' || import.meta.env.VITE_ENV === 'STAGING') {
-  // const localTheme = window.localStorage.getItem('localTheme')
-  const localTheme = null
-  selectedTheme = localTheme ? THEMES[localTheme] : selectedTheme
+const ThemeProvider = ({ children }) => {
+  const { activeHackathon } = useHackathon()
+  const selectedTheme = THEMES[activeHackathon]
+
+  return <TP theme={selectedTheme}>{children}</TP>
 }
-
-const ThemeProvider = ({ children }) => <TP theme={selectedTheme}>{children}</TP>
 
 export default ThemeProvider

--- a/src/theme/ThemeProvider.jsx
+++ b/src/theme/ThemeProvider.jsx
@@ -43,7 +43,7 @@ const base = {
 
 const nwHacksTheme = {
   ...base,
-  name: 'nwHacks',
+  name: 'nwhacks',
   colors: {
     background: '#3C4BA5', // Background
     card: '#0A1361', // BG Accent
@@ -119,7 +119,7 @@ const nwHacksTheme = {
 
 const hackcampTheme = {
   ...base,
-  name: 'hackCamp',
+  name: 'hackcamp',
   colors: {
     background: '#150C27',
     card: '#433860',

--- a/src/theme/ThemeProvider.jsx
+++ b/src/theme/ThemeProvider.jsx
@@ -128,6 +128,7 @@ const hackcampTheme = {
     secondaryBackground: '#150C27',
     secondaryBackgroundTransparent: '#fff',
     sidebar: {
+      background: '#150C27',
       link: '#F0EEF299',
     },
     foreground: '#FFFFFF',

--- a/src/utility/Auth.jsx
+++ b/src/utility/Auth.jsx
@@ -56,7 +56,7 @@ export function AuthProvider({ children }) {
   )
 }
 
-const handleUser = async (setUser, setLocation) => {
+const handleUser = async (setUser, setLocation, activeHackathon) => {
   const user = firebase.auth().currentUser
   const { redirect, status } = await getUserStatus(user)
   // alert(redirect, status)
@@ -67,35 +67,40 @@ const handleUser = async (setUser, setLocation) => {
   setUser(user)
   analytics.setUserId(user.uid)
   analytics.logEvent(ANALYTICS_EVENTS.Login, { userId: user.uid })
-  await handleRedirect(redirect, setLocation)
+  await handleRedirect(redirect, setLocation, activeHackathon)
 }
 
-export const getRedirectUrl = redirect => {
+export const getRedirectUrl = (redirect, activeHackathon) => {
   switch (redirect) {
     case REDIRECT_STATUS.AttendingEvent:
-      return '/'
+      return `/app/${activeHackathon}`
     case REDIRECT_STATUS.ApplicationAccepted:
-      return '/'
+      return `/app/${activeHackathon}`
     case REDIRECT_STATUS.ApplicationNotSubmitted:
-      return '/application/part-0'
+      return `/app/${activeHackathon}/application/part-0`
     case REDIRECT_STATUS.ApplicationSubmitted:
+      return `/app/${activeHackathon}`
     default:
-      return '/application'
+      return `/app/${activeHackathon}/application`
   }
 }
 
-export const handleRedirect = async (redirect, setLocationCallback) => {
+export const handleRedirect = async (redirect, setLocationCallback, activeHackathon) => {
   // alert(redirect, getRedirectUrl(redirect))
   const submissionOpen = (await livesiteDocRef.get()).data().submissionsOpen
-  setLocationCallback(submissionOpen ? '/submission' : getRedirectUrl(redirect))
+  setLocationCallback(
+    submissionOpen
+      ? `/app/${activeHackathon}/submission`
+      : getRedirectUrl(redirect, activeHackathon)
+  )
 }
 
-export const googleSignIn = async (setUser, setLocation) => {
+export const googleSignIn = async (setUser, setLocation, activeHackathon) => {
   await firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL)
   const provider = new firebase.auth.GoogleAuthProvider()
   try {
     await firebase.auth().signInWithPopup(provider)
-    await handleUser(setUser, setLocation)
+    await handleUser(setUser, setLocation, activeHackathon)
     return null
   } catch (e) {
     console.error(e)
@@ -103,12 +108,12 @@ export const googleSignIn = async (setUser, setLocation) => {
   }
 }
 
-export const githubSignIn = async (setUser, setLocation) => {
+export const githubSignIn = async (setUser, setLocation, activeHackathon) => {
   await firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL)
   const provider = new firebase.auth.GithubAuthProvider()
   try {
     await firebase.auth().signInWithPopup(provider)
-    await handleUser(setUser, setLocation)
+    await handleUser(setUser, setLocation, activeHackathon)
     return null
   } catch (e) {
     return e

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -2,6 +2,12 @@ export const DB_COLLECTION = 'Hackathons'
 
 // CHANGE: firebase collection name for this hackathon
 export const DB_HACKATHON = 'cmd-f2024'
+export const DB_HACKATHON_NAMES = {
+  'hackcamp': 'HackCamp2023',
+  'nwhacks': 'nwHacks2024',
+  'cmd-f': 'cmd-f2024',
+}
+export const VALID_HACKATHONS = ['hackcamp', 'nwhacks', 'cmd-f']
 export const DAYOF_COLLECTION = 'DayOf'
 export const FAQ_COLLECTION = 'FAQ'
 export const NOTIFICATION_SETTINGS_CACHE_KEY = 'livesiteNotificationSettings'

--- a/src/utility/HackathonProvider.jsx
+++ b/src/utility/HackathonProvider.jsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+import { DB_HACKATHON_NAMES } from './Constants'
+
+const VALID_HACKATHONS = ['HackCamp', 'nwHacks', 'cmd-f']
+
+function getValidHackathon(hackathon) {
+  return VALID_HACKATHONS.includes(hackathon) ? hackathon : 'nwHacks'
+}
+
+const HackathonContext = createContext()
+
+export const useHackathon = () => useContext(HackathonContext)
+
+export default function HackathonProvider({ children }) {
+  const [activeHackathon, setActiveHackathon] = useState(() => {
+    return getValidHackathon(localStorage.getItem('activeHackathon'))
+  })
+  const [dbHackathonName, setDbHackathonName] = useState(DB_HACKATHON_NAMES[activeHackathon])
+
+  useEffect(() => {
+    localStorage.setItem('activeHackathon', activeHackathon)
+    setDbHackathonName(DB_HACKATHON_NAMES[activeHackathon])
+  }, [activeHackathon])
+
+  return (
+    <HackathonContext.Provider value={{ activeHackathon, setActiveHackathon, dbHackathonName }}>
+      {children}
+    </HackathonContext.Provider>
+  )
+}

--- a/src/utility/HackathonProvider.jsx
+++ b/src/utility/HackathonProvider.jsx
@@ -1,25 +1,39 @@
 import { createContext, useContext, useState, useEffect } from 'react'
-import { DB_HACKATHON_NAMES } from './Constants'
-
-const VALID_HACKATHONS = ['HackCamp', 'nwHacks', 'cmd-f']
-
-function getValidHackathon(hackathon) {
-  return VALID_HACKATHONS.includes(hackathon) ? hackathon : 'nwHacks'
-}
+import { DB_HACKATHON_NAMES, VALID_HACKATHONS } from './Constants'
 
 const HackathonContext = createContext()
 
-export const useHackathon = () => useContext(HackathonContext)
+export const useHackathon = function () {
+  return useContext(HackathonContext)
+}
+
+function getValidHackathon(hackathon) {
+  return VALID_HACKATHONS.includes(hackathon) ? hackathon : 'nwhacks'
+}
 
 export default function HackathonProvider({ children }) {
-  const [activeHackathon, setActiveHackathon] = useState(() => {
-    return getValidHackathon(localStorage.getItem('activeHackathon'))
-  })
-  const [dbHackathonName, setDbHackathonName] = useState(DB_HACKATHON_NAMES[activeHackathon])
+  const storedHackathon = localStorage.getItem('activeHackathon')
+  const initialHackathon = getValidHackathon(storedHackathon || '')
+  const [activeHackathon, setActiveHackathon] = useState(initialHackathon)
+  const [dbHackathonName, setDbHackathonName] = useState(DB_HACKATHON_NAMES[initialHackathon])
 
   useEffect(() => {
     localStorage.setItem('activeHackathon', activeHackathon)
     setDbHackathonName(DB_HACKATHON_NAMES[activeHackathon])
+
+    switch (activeHackathon) {
+      case 'hackcamp':
+        document.title = 'HackCamp Hacker Portal'
+        break
+      case 'nwhacks':
+        document.title = 'nwHacks Hacker Portal'
+        break
+      case 'cmd-f':
+        document.title = 'cmd-f Hacker Portal'
+        break
+      default:
+        document.title = 'Hacker Portal'
+    }
   }, [activeHackathon])
 
   return (

--- a/src/utility/HackerApplicationContext.jsx
+++ b/src/utility/HackerApplicationContext.jsx
@@ -156,15 +156,15 @@ export function HackerApplicationProvider({ children }) {
     })
   }, [])
 
-  /**applicationOpen hasn't loaded ? show a spinner
-   * Applications are closed ? show message
-   * Applications are open ? Show application
-   */
-  return applicationOpen === null || application === undefined ? (
-    <Spinner />
-  ) : !applicationOpen && window.location.pathname !== '/application' ? (
-    <Closed />
-  ) : (
+  if (applicationOpen === null || application === undefined) {
+    return null
+  }
+
+  if (!applicationOpen && window.location.pathname !== '/application') {
+    return <Closed />
+  }
+
+  return (
     <HackerApplicationContext.Provider value={{ application, updateApplication, forceSave }}>
       {children}
     </HackerApplicationContext.Provider>

--- a/src/utility/Routes.jsx
+++ b/src/utility/Routes.jsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { Route, Redirect } from 'wouter'
+import { getLivesiteDoc } from './firebase'
+import Page from '../components/Page'
+import { useAuth, getRedirectUrl } from './Auth'
+import { APPLICATION_STATUS } from './Constants'
+import Navbar from '../components/Navbar'
+import { useHackathon } from './HackathonProvider'
+
+export const PageRoute = ({ path, children }) => {
+  const [livesiteDoc, setLivesiteDoc] = useState(null)
+
+  useEffect(() => {
+    const unsubscribe = getLivesiteDoc(setLivesiteDoc)
+    return unsubscribe
+  }, [])
+
+  return (
+    <Route path={path}>
+      {livesiteDoc?.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
+    </Route>
+  )
+}
+
+export const AuthPageRoute = ({ path, children }) => {
+  const { isAuthed, user } = useAuth()
+
+  if (!isAuthed) {
+    return (
+      <Route path={path}>
+        <Redirect to="~/login" />
+      </Route>
+    )
+  }
+  return (
+    <Route path={path}>
+      {user?.status === APPLICATION_STATUS.accepted ? (
+        <Page>{children}</Page>
+      ) : (
+        <Redirect to="/application/closed" />
+      )}
+    </Route>
+  )
+}
+
+export const ApplicationInProgressRoute = ({ name, handleLogout, path, children }) => {
+  const { isAuthed, user, logout } = useAuth()
+
+  return isAuthed ? (
+    <Route path={path}>
+      <Navbar
+        name={name ? user.displayName : undefined}
+        handleLogout={handleLogout ? logout : undefined}
+      >
+        {children}
+      </Navbar>
+    </Route>
+  ) : (
+    <Redirect to="~/login" />
+  )
+}
+
+export const NoAuthRoute = ({ path, children }) => {
+  const { isAuthed, user } = useAuth()
+  const { activeHackathon } = useHackathon()
+
+  return (
+    <Route path={path}>
+      {!isAuthed ? children : <Redirect to={getRedirectUrl(user.redirect, activeHackathon)} />}
+    </Route>
+  )
+}
+
+export const AdminAuthPageRoute = ({ path, children }) => {
+  const { isAuthed, user } = useAuth()
+
+  if (!isAuthed) {
+    return <Redirect to="~/login" />
+  }
+
+  return <Route path={path}>{user.admin ? <Page>{children}</Page> : <Redirect to="~/404" />}</Route>
+}

--- a/src/utility/Routes.jsx
+++ b/src/utility/Routes.jsx
@@ -2,9 +2,10 @@ import { useEffect, useState } from 'react'
 import { Route, Router, Redirect, useRouter, useLocation } from 'wouter'
 import { getLivesiteDoc } from './firebase'
 import Page from '../components/Page'
+import Loading from '../components/Loading'
+import Navbar from '../components/Navbar'
 import { useAuth, getRedirectUrl } from './Auth'
 import { APPLICATION_STATUS, VALID_HACKATHONS } from './Constants'
-import Navbar from '../components/Navbar'
 import { useHackathon } from './HackathonProvider'
 
 const NestedRoutes = props => {
@@ -41,12 +42,12 @@ const PageRoute = ({ path, children }) => {
   }, [])
 
   if (livesiteDoc === null) {
-    return null
+    return <Loading />
   }
 
   return (
     <Route path={path}>
-      {livesiteDoc.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
+      {livesiteDoc?.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
     </Route>
   )
 }

--- a/src/utility/Routes.jsx
+++ b/src/utility/Routes.jsx
@@ -40,9 +40,13 @@ const PageRoute = ({ path, children }) => {
     return unsubscribe
   }, [])
 
+  if (livesiteDoc === null) {
+    return null
+  }
+
   return (
     <Route path={path}>
-      {livesiteDoc?.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
+      {livesiteDoc.applicationsOpen ? <Redirect to="/application" /> : <Page>{children}</Page>}
     </Route>
   )
 }

--- a/src/utility/RoutingContainers.jsx
+++ b/src/utility/RoutingContainers.jsx
@@ -1,0 +1,71 @@
+import { Redirect } from 'wouter'
+import Form from '../components/ApplicationForm'
+import Navbar from '../components/Navbar'
+import Page from '../components/Page'
+import { Application, ApplicationForm, Gallery, JudgingView, ProjectView } from '../pages'
+import { useAuth } from './Auth'
+import { APPLICATION_STATUS } from './Constants'
+import { useHackerApplication } from './HackerApplicationContext'
+
+const NavbarSaveOnLogout = ({ name, handleLogout }) => {
+  const { forceSave } = useHackerApplication()
+  const logout = async () => {
+    await forceSave()
+    handleLogout()
+  }
+
+  return <Navbar name={name} handleLogout={logout} />
+}
+
+const ApplicationFormContainer = ({ part }) => {
+  const { isAuthed, user, logout } = useAuth()
+  const { application } = useHackerApplication()
+
+  return isAuthed && application.status.applicationStatus === APPLICATION_STATUS.inProgress ? (
+    <>
+      <NavbarSaveOnLogout name={user.displayName} handleLogout={logout} />
+      <Form>
+        <ApplicationForm part={part} />
+      </Form>
+    </>
+  ) : (
+    <Redirect to="~/login" />
+  )
+}
+
+const ApplicationDashboardRoutingContainer = () => {
+  const { isAuthed } = useAuth()
+  return isAuthed ? <Application /> : <Redirect to="~/login" />
+}
+
+const JudgingViewContainer = ({ params }) => {
+  const { isAuthed } = useAuth()
+
+  return isAuthed ? (
+    <Page>
+      <JudgingView id={params.id} />
+    </Page>
+  ) : (
+    <Redirect to="~/login" />
+  )
+}
+
+const GalleryContainer = () => (
+  <Page>
+    <Gallery />
+  </Page>
+)
+
+const ProjectViewContainer = ({ params }) => (
+  <Page>
+    <ProjectView pid={params.id} />
+  </Page>
+)
+
+export {
+  ApplicationDashboardRoutingContainer,
+  ApplicationFormContainer,
+  GalleryContainer,
+  JudgingViewContainer,
+  ProjectViewContainer,
+}


### PR DESCRIPTION
## Description
Documentation: https://www.notion.so/Portal-Documentation-3a2b518a80fa4b9e8dca2d788267730f?pvs=4
- Created a hackathon context to keep track of the active hackathon (one of `hackcamp`, `nwhacks`, and `cmd-f` -> yes ik they're lowercase :angrycry:) as well as the corresponding firebase collection's name
- Whenever the user navigates to a page with a /app/:hackathon/ url, the active hackathon gets set in context + local storage (so that it persists through refreshes) -> this gets cleared when the user navigates back to the home page
- The current theme is also automatically set based on the `activeHackathon` value and it defaults to `nwhacks` to prevent the app going bananas when there's no active theme (since a lot of the components read from the theme)
- Also fixed up some small misc. bugs I ran into while testing but I can move them into another PR if this PR is too big

## Testing
- Change [this](https://github.com/nwplus/portal/blob/ee8e9eb2206445b582d4b27a4a76209333960e4d/src/utility/firebase.js#L43-L47) to the code snippet below to toggle between the application status while testing since the app redirects users to `/app/:hackathon/application` when applications are open
```
export const getLivesiteDoc = callback => {
  return livesiteDocRef.onSnapshot(doc => {
    const data = doc.data()
    data.applicationsOpen = false (or true)
    callback(data)
  })
}
```
- go ham with navigating through the different pages (but not too ham), some of them require admin perms (use your nw email)