### PR TITLE
Fix white screen while refreshing application

### DIFF
--- a/src/utility/HackerApplicationContext.jsx
+++ b/src/utility/HackerApplicationContext.jsx
@@ -42,7 +42,7 @@ export const uploadWaiverToStorage = async (userId, file) => {
 
 export function HackerApplicationProvider({ children }) {
   const { user } = useAuth()
-  const [application, setApplication] = useState(initialApplication)
+  const [application, setApplication] = useState(null)
   const [, setUpdated] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(null)
   const applicationRef = useRef()

--- a/src/utility/HackerApplicationContext.jsx
+++ b/src/utility/HackerApplicationContext.jsx
@@ -163,7 +163,7 @@ export function HackerApplicationProvider({ children }) {
     })
   }, [])
 
-  if (isLoading || applicationOpen === null) {
+  if (isLoading || applicationOpen === null || application === null) {
     return null
   }
 

--- a/src/utility/HackerApplicationContext.jsx
+++ b/src/utility/HackerApplicationContext.jsx
@@ -42,20 +42,26 @@ export const uploadWaiverToStorage = async (userId, file) => {
 
 export function HackerApplicationProvider({ children }) {
   const { user } = useAuth()
-  const [application, setApplication] = useState(HACKER_APPLICATION_TEMPLATE)
+  const [application, setApplication] = useState(initialApplication)
   const [, setUpdated] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(null)
   const applicationRef = useRef()
   const { dbHackathonName } = useHackathon()
+  const [isLoading, setIsLoading] = useState(true)
 
   /**Initialize retrieval of hacker application */
   useEffect(() => {
     const retrieveApplication = async () => {
-      if (!user) return
+      if (!user) {
+        setIsLoading(false)
+        return
+      }
+
       const app = await getUserApplication(user.uid, dbHackathonName)
       fillMissingProperties(app, HACKER_APPLICATION_TEMPLATE)
       setApplication(app)
       setUpdated(false)
+      setIsLoading(false)
       analytics.logEvent(ANALYTICS_EVENTS.AccessApplication, { userId: user.uid })
     }
     retrieveApplication()
@@ -158,7 +164,7 @@ export function HackerApplicationProvider({ children }) {
     })
   }, [])
 
-  if (applicationOpen === null || application === undefined) {
+  if (isLoading || applicationOpen === null) {
     return null
   }
 

--- a/src/utility/HackerApplicationContext.jsx
+++ b/src/utility/HackerApplicationContext.jsx
@@ -56,7 +56,6 @@ export function HackerApplicationProvider({ children }) {
         setIsLoading(false)
         return
       }
-
       const app = await getUserApplication(user.uid, dbHackathonName)
       fillMissingProperties(app, HACKER_APPLICATION_TEMPLATE)
       setApplication(app)


### PR DESCRIPTION
## Description
- Set the default state for the application to be `null` instead of `HACKER_APPLICATION_TEMPLATE` to better communicate that the application hasn't been loaded yet (versus just an empty application)
- Added a loading state to stop the rendering of any of the children components until `application` has been loaded from firebase
I think the reason why it's broken rn is because it now takes slightly longer to load the application from firebase, and causing the context provider to prematurely give `Part0.jsx` the default value of `HACKER_APPLICATION_TEMPLATE` (which is a blank application) instead of the actual application from firebase. Instead, the value for the application should be `null` until the application is loaded.

## Testing
dev branch
- run the current dev branch (or go to the [preview link](https://dev-nwplus-portal.web.app/))
- select cmd-f, and click complete a registration (you should be brought to the part 0 page)
- reload, there should be a white screen with some error messages in the console saying `TypeError: u.toDate is not a function`

this branch
- do the same on this branch (or using the preview link for this PR)
- you should be able to refresh the part 0 page without any errors
- edit your application/go through the application process and double check that everything still updates in firebase (just in case LOL)
