### PR TITLE
Fix redirect on application dashboard when apps are closed

### DIFF
--- a/src/utility/HackerApplicationContext.jsx
+++ b/src/utility/HackerApplicationContext.jsx
@@ -211,7 +211,7 @@ export function HackerApplicationProvider({ children }) {
     return null
   }
 
-  if (!applicationOpen && window.location.pathname !== '/application') {
+  if (!applicationOpen && !window.location.pathname.endsWith('/application')) {
     return <Closed />
   }
 


### PR DESCRIPTION
... my bad

## Description
When applications are closed, the user should still be able to access the dashboard (to see their status or RSVP). I forgot to update this logic when we moved to the new routing structure because the pathname used to be `application`, but now it's `app/[hackathon]/application`
