### PR TITLE
only access portal when is live

### DIFF
--- a/src/utility/Routes.jsx
+++ b/src/utility/Routes.jsx
@@ -49,7 +49,8 @@ const PageRoute = ({ path, children }) => {
 
   return (
     <Route path={path}>
-      {livesiteDoc?.applicationsOpen[activeHackathon] ? (
+      {livesiteDoc?.applicationsOpen[activeHackathon] ||
+      !livesiteDoc?.portalLive[activeHackathon] ? (
         <Redirect to="/application" />
       ) : (
         <Page>{children}</Page>


### PR DESCRIPTION
If portal isn't live yet (schedule, sponsors, etc haven't been added), users can only see their application status (awaiting assessment, rsvped, etc). If they never applied, take them to apply next year


Added a new schema. Set to true when portal is live -> users can see ticket, schedule, etc.
![image](https://github.com/user-attachments/assets/1e1ce59a-b47e-422e-8911-e6160587a25d)
