### PR TITLE
Allow admins to view application pages anytime

### DIFF
--- a/src/utility/HackerApplicationContext.jsx
+++ b/src/utility/HackerApplicationContext.jsx
@@ -211,7 +211,9 @@ export function HackerApplicationProvider({ children }) {
     return null
   }
 
-  if (!applicationOpen && !window.location.pathname.endsWith('/application')) {
+  const canViewApplication =
+    applicationOpen || window.location.pathname.endsWith('/application') || user?.admin
+  if (!canViewApplication) {
     return <Closed />
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes! Include motivation, changes you made, screenshots/video if applicable -->
Allows admins to access the hacker application pages through `/app/{activeHackathon}/application/page-x` even when apps are not open yet so they can view the app questions

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
