### PR TITLE
use url instead of localstorage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,6 @@ function App() {
 
   useEffect(() => {
     if (location === '/') {
-      localStorage.removeItem('activeHackathon')
       document.title = 'Hacker Portal'
     }
   }, [location])

--- a/src/components/HackathonCard.jsx
+++ b/src/components/HackathonCard.jsx
@@ -219,7 +219,6 @@ const HackathonCard = ({
   isUpNext,
 }) => {
   const [_, navigate] = useLocation()
-  const { setActiveHackathon } = useHackathon()
 
   return (
     <StyledHackathonCard background={background} isUpNext={isUpNext}>
@@ -247,7 +246,6 @@ const HackathonCard = ({
             color={buttonColour}
             labelColor={buttonTextColour}
             onClick={() => {
-              setActiveHackathon(hackathonName.toLowerCase())
               handleNavigation(applicationOpen, visitWebsite, hackathonName, navigate)
             }}
             hoverColor={buttonHoverColor}

--- a/src/pages/Charcuterie.jsx
+++ b/src/pages/Charcuterie.jsx
@@ -56,7 +56,7 @@ const toggleTheme = (navigate, activeHackathon) => {
 }
 
 const Charcuterie = () => {
-  const { activeHackathon, setActiveHackathon } = useHackathon()
+  const { activeHackathon } = useHackathon()
   const [_, navigate] = useLocation()
   const [states, setStates] = useState({
     checkbox: false,
@@ -77,11 +77,7 @@ const Charcuterie = () => {
   `
   return (
     <>
-      <Button
-        color="secondary"
-        width="flex"
-        onClick={() => toggleTheme(navigate, activeHackathon, setActiveHackathon)}
-      >
+      <Button color="secondary" width="flex" onClick={() => toggleTheme(navigate, activeHackathon)}>
         Toggle Theme
       </Button>
       <Button color="secondary" width="flex" onClick={() => setIsLoading(!isLoading)}>

--- a/src/utility/HackathonProvider.jsx
+++ b/src/utility/HackathonProvider.jsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react'
+import { useLocation } from 'wouter'
 import { DB_HACKATHON_NAMES, VALID_HACKATHONS } from './Constants'
 
 const HackathonContext = createContext()
@@ -12,15 +13,15 @@ function getValidHackathon(hackathon) {
 }
 
 export default function HackathonProvider({ children }) {
-  const storedHackathon = localStorage.getItem('activeHackathon')
-  const initialHackathon = getValidHackathon(storedHackathon || '')
-  const [activeHackathon, setActiveHackathon] = useState(initialHackathon)
-  const [dbHackathonName, setDbHackathonName] = useState(DB_HACKATHON_NAMES[initialHackathon])
+  const [location] = useLocation()
+  const urlHackathon = location.split('/')[2]?.toLowerCase()
+  const [activeHackathon, setActiveHackathon] = useState(getValidHackathon(urlHackathon || ''))
+  const dbHackathonName = DB_HACKATHON_NAMES[activeHackathon]
 
   useEffect(() => {
-    localStorage.setItem('activeHackathon', activeHackathon)
-    setDbHackathonName(DB_HACKATHON_NAMES[activeHackathon])
-  }, [activeHackathon])
+    const newHackathon = getValidHackathon(urlHackathon || '')
+    setActiveHackathon(newHackathon)
+  }, [location])
 
   return (
     <HackathonContext.Provider value={{ activeHackathon, setActiveHackathon, dbHackathonName }}>

--- a/src/utility/HackathonProvider.jsx
+++ b/src/utility/HackathonProvider.jsx
@@ -15,16 +15,11 @@ function getValidHackathon(hackathon) {
 export default function HackathonProvider({ children }) {
   const [location] = useLocation()
   const urlHackathon = location.split('/')[2]?.toLowerCase()
-  const [activeHackathon, setActiveHackathon] = useState(getValidHackathon(urlHackathon || ''))
+  const activeHackathon = getValidHackathon(urlHackathon || '')
   const dbHackathonName = DB_HACKATHON_NAMES[activeHackathon]
 
-  useEffect(() => {
-    const newHackathon = getValidHackathon(urlHackathon || '')
-    setActiveHackathon(newHackathon)
-  }, [location])
-
   return (
-    <HackathonContext.Provider value={{ activeHackathon, setActiveHackathon, dbHackathonName }}>
+    <HackathonContext.Provider value={{ activeHackathon, dbHackathonName }}>
       {children}
     </HackathonContext.Provider>
   )

--- a/src/utility/Routes.jsx
+++ b/src/utility/Routes.jsx
@@ -11,15 +11,7 @@ import { useHackathon } from './HackathonProvider'
 const NestedRoutes = props => {
   const router = useRouter()
   const [location] = useLocation()
-  const { activeHackathon, setActiveHackathon } = useHackathon()
   const hackathonFromURL = props.base.split('/')[2].toLowerCase()
-
-  useEffect(() => {
-    if (VALID_HACKATHONS.includes(hackathonFromURL)) {
-      setActiveHackathon(hackathonFromURL)
-      localStorage.setItem('activeHackathon', activeHackathon)
-    }
-  }, [props.base, activeHackathon, setActiveHackathon])
 
   if (!location.startsWith(props.base)) return null
 


### PR DESCRIPTION
Ticket: https://www.notion.so/nwplus/Investigate-localstorage-overwrite-14e14d529faa809f8043f9717d4e0b20
## Description
<!--- Describe your changes! Include motivation, changes you made, screenshots/video if applicable -->
- nuked localstorage in favour of reading the state from the url to create an independent single source of truth (solves the issue of localstorage values persisting through different tabs)
- simplified `activeHackathon` and `dbHackathonName` to be derived values instead of managed states

The idea is that whenever the url changes:
- `useLocation()` triggers a re-render of `HackathonProvider`
- `urlHackathon` is recalculated from the new URL
- `activeHackathon` gets derived from `urlHackathon` and `dbHackathonName` is derived from `activeHackathon`

## Testing
- navigate through different pages, change the url, etc.
- testing the workflow that made things glitchy:
	- fill out an application for hackcamp
	- go to the dev firebase db and give yourself a status of `acceptedAndAttending`
	- delete your applicant object from `nwHacks2025/Applicants` if you already have an existing application
	- from the application page (`/app/hackcamp/application`), navigate to `app/nwhacks/application/part-1` by changing the url manually
	- check the `nwHacks2025/Applicants` collection to see if you have a new blank object (previously, your application from hackcamp would be copied over)
