### PR TITLE
portal rewards - 

### DIFF
--- a/src/components/RewardCard.jsx
+++ b/src/components/RewardCard.jsx
@@ -136,23 +136,25 @@ const RewardCard = ({ name, type, desc, company, image, points, requiredPoints }
             ) : (
               <Text>Reach {requiredPoints - points} pts</Text>
             )}
-            {type && <Text>Type: {type}</Text>}
+            {type === 'Raffle' ? <Text>Raffle Prize</Text> : type && <Text>Type: {type}</Text>}
           </div>
         </Grid>
-        <div style={{ justifyContent: 'center', alignItems: 'center' }}>
-          {points >= requiredPoints ? (
-            <SubTitle>
-              {requiredPoints}/{requiredPoints} pts
-            </SubTitle>
-          ) : (
-            <SubTitle>
-              {points}/{requiredPoints} pts
-            </SubTitle>
-          )}
-          <ProgressContainer>
-            <ProgressBar value={progress} />
-          </ProgressContainer>
-        </div>
+        {points > 0 && (
+          <div style={{ justifyContent: 'center', alignItems: 'center' }}>
+            {points >= requiredPoints ? (
+              <SubTitle>
+                {requiredPoints}/{requiredPoints} pts
+              </SubTitle>
+            ) : (
+              <SubTitle>
+                {points}/{requiredPoints} pts
+              </SubTitle>
+            )}
+            <ProgressContainer>
+              <ProgressBar value={progress} />
+            </ProgressContainer>
+          </div>
+        )}
       </Container>
 
       <Back onClick={handleClick}>

--- a/src/components/RewardCard.jsx
+++ b/src/components/RewardCard.jsx
@@ -107,7 +107,7 @@ const Back = styled.div`
   cursor: pointer;
 `
 
-const RewardCard = ({ name, desc, company, image, points, requiredPoints }) => {
+const RewardCard = ({ name, type, desc, company, image, points, requiredPoints }) => {
   const [isFlipped, setIsFlipped] = useState(false)
 
   const handleClick = e => {
@@ -136,6 +136,7 @@ const RewardCard = ({ name, desc, company, image, points, requiredPoints }) => {
             ) : (
               <Text>Reach {requiredPoints - points} pts</Text>
             )}
+            {type && <Text>Type: {type}</Text>}
           </div>
         </Grid>
         <div style={{ justifyContent: 'center', alignItems: 'center' }}>

--- a/src/containers/Rewards.jsx
+++ b/src/containers/Rewards.jsx
@@ -147,6 +147,7 @@ const Rewards = () => {
             <RewardCard
               key={index}
               name={reward.reward}
+              type={reward.type}
               desc={reward.blurb}
               company={reward.from}
               image={reward.imgURL}


### PR DESCRIPTION
## Description
- on portal -> rewards, added an extra field to specify which type each prize is
ex of a prize w/ no type field (same as original)
<img width="383" alt="Screen Shot 2025-01-09 at 5 43 33 PM" src="https://github.com/user-attachments/assets/4f7eb95c-ef0a-402b-97fe-4041abd679e0" />

ex of a prize w/ a type field (newly added)
<img width="371" alt="Screen Shot 2025-01-09 at 5 43 42 PM" src="https://github.com/user-attachments/assets/5c13ff22-1f47-4496-a7a5-090e13af9859" />

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
