### PR TITLE
save to images/download functionality

### DIFF
--- a/src/pages/HackathonSelection.jsx
+++ b/src/pages/HackathonSelection.jsx
@@ -119,7 +119,6 @@ export default function HackathonSelection() {
         buttonHoverColor={'linear-gradient(90deg, #00DBCE 0%, #00D88A 100%)'}
         applicationDeadline={applicationData.deadlines.hackcamp}
         applicationOpen={applicationData.openStatuses.hackcamp}
-        visitWebsite
       />
       <HackathonCard
         background="linear-gradient(180deg, #77F8EF 0%, #007A72 123.72%)"


### PR DESCRIPTION
## Description
<!--- Describe your changes! Include motivation, changes you made, screenshots/video if applicable -->

Download (desktop) and Save to Images (mobile) functionality for QR codes. 

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->

New Desktop View
<img width="3420" height="2214" alt="image" src="https://github.com/user-attachments/assets/cece908e-ceb9-4185-bd93-e8695722da44" />

New Mobile View
<img width="784" height="1686" alt="image" src="https://github.com/user-attachments/assets/68ae0691-4c1f-4062-a968-2df1eeaf1cda" />

Downloaded Image preview
<img width="443" height="584" alt="image" src="https://github.com/user-attachments/assets/07bc365b-897c-4752-bd7b-749cfdb9ffaf" />

How it Works: 
1. Reformatted QR Ticket DOM structure to be simpler
2. Generate canvas from ticket, convert to blob
3. If mobile, use default share functionality 
4. If errors occur or are on a desktop, creates a link to the image and automatically downloads. 

User Exp:
- Mobile: Press "download image", opens up default sharing popup, can save to images, downloads, share in text etc.
- Desktop: press button, yay image downloaded. 

Problems/Caveats:
- nwHacks background svg doesn't specify height/width, making it appear super zoomed in on download. Hackcamp and cmd-f background/downloads are fine. For future hackathon background images, specify height and width. 

- Deleted "visitWebsite" attribute for HackCamp so you can visit portal and see your QR Code. Need to change your application status to "acceptedAndAttending" in firebase (Hackathons -> HackCamp2024 -> Applicants -> Your application). 

