### PR TITLE
bug: add back notion link to pre-hackathon workshops

### DIFF
--- a/src/components/ApplicationDashboard.jsx
+++ b/src/components/ApplicationDashboard.jsx
@@ -229,8 +229,17 @@ export const hackerStatuses = (relevantDates, hackerName = null, activeHackathon
         {relevantDates?.offWaitlistNotify} if we find a spot for you, so please check your email
         then!
         <HR />
-        We are currently at full capacity, but everyone is welcome to attend our pre-hackathon
-        workshops.
+        We are currently at full capacity, but everyone is welcome to attend our{' '}
+        <A
+          href={notionLinks?.preHackathonWorkshops}
+          target="_blank"
+          rel="noopener noreferrer"
+          bolded
+          color="primary"
+        >
+          pre-hackathon workshops
+        </A>
+        .
       </>
     ),
   },


### PR DESCRIPTION
## Description
Removed link to the notion page for pre-hackathon workshops by accident, adding the link back now
<img width="1906" height="952" alt="Screenshot 2025-09-30 at 10 57 43 PM" src="https://github.com/user-attachments/assets/e31ab101-90a1-47cb-a519-05077986a050" />
